### PR TITLE
Remove solution-circuit toggle and fix visualization processing

### DIFF
--- a/components/Visualization/QuantumCircuitVis.js
+++ b/components/Visualization/QuantumCircuitVis.js
@@ -200,7 +200,7 @@ const QuantumCircuitVis = ({
         if (toolbar) toolbar.remove();
         const board = dom.querySelector(".Q-circuit-board");
         if (board) {
-          board.style.pointerEvents = "none";
+          board.style.pointerEvents = "auto";
           board.style.userSelect = "none";
         }
       } else {

--- a/components/Visualization/svgs/Visualizations.js
+++ b/components/Visualization/svgs/Visualizations.js
@@ -4,7 +4,7 @@ import StandardCircuitSvgReact from "./StandardCircuitSvgReact";
 import QuantumCircuitVis from "../QuantumCircuitVis";
 
 const Visualizations = new Map([
-    ["Boolean Satisfiability" , (solve, url, problemData, gadgetMap, gadgetsOn, extra) => {
+    ["Boolean Satisfiability" , (solve, url, problemData, gadgetMap, gadgetsOn) => {
         return(
             <StandardSATSvgReact 
                 problemData={problemData}
@@ -15,7 +15,7 @@ const Visualizations = new Map([
             ></StandardSATSvgReact>  
         )
     }],
-    ["Graph D3", (solve, url, problemData, gadgetMap, gadgetsOn, extra)=>{
+    ["Graph D3", (solve, url, problemData, gadgetMap, gadgetsOn)=>{
         return(
         <StandardGraphSvgReact 
             problemData={problemData}
@@ -26,7 +26,7 @@ const Visualizations = new Map([
         ></StandardGraphSvgReact>
         )
     }],
-    ["Quantum Circuit D3", (solve, url, problemData, gadgetMap, gadgetsOn, extra)=>{
+    ["Quantum Circuit D3", (solve, url, problemData, gadgetMap, gadgetsOn)=>{
         return(
         <StandardCircuitSvgReact
             problemData={problemData}
@@ -34,11 +34,10 @@ const Visualizations = new Map([
             url={url}
             gadgetMap={gadgetMap}
             gadgetsOn={gadgetsOn}
-            useSolutionCircuit={extra?.showSolutionCircuit}
         ></StandardCircuitSvgReact>
         )
     }],
-    ["Quantum Circuit Q.js", (solve, url, problemData, gadgetMap, gadgetsOn, extra) => {
+    ["Quantum Circuit Q.js", (solve, url, problemData, gadgetMap, gadgetsOn) => {
         return (
             <QuantumCircuitVis
                 problemData={problemData}
@@ -46,7 +45,6 @@ const Visualizations = new Map([
                 url={url}
                 gadgetMap={gadgetMap}
                 gadgetsOn={gadgetsOn}
-                useSolutionCircuit={extra?.showSolutionCircuit}
             />
         );
     }],

--- a/components/pageblocks/VisualizeRowReact.js
+++ b/components/pageblocks/VisualizeRowReact.js
@@ -94,11 +94,9 @@ export default function VisualizeRowReact({
   const [showSolution, setShowSolution] = useState(false);
   const [showGadgets, setShowGadgets] = useState(false);
   const [showReduction, setShowReduction] = useState(false);
-  const [showSolutionCircuit, setShowSolutionCircuit] = useState(false);
   const [disableGadget, setDisableGadget] = useState(false);
   const [disableSolution, setDisableSolution] = useState(true);
   const [disableReduction, setDisableReduction] = useState(!chosenReductionType);
-  const [hasSolutionCircuit, setHasSolutionCircuit] = useState(false);
 
   const [problemVisualizationData, setProblemVisualizationData] = useState(
     defaultSat3VisualizationArr
@@ -117,7 +115,6 @@ export default function VisualizeRowReact({
 
   const isDisabled = showGadgets || showReduction;
   const totalSteps = problemData.length;
-  const disableSolutionCircuit = !hasSolutionCircuit;
 
   // Track when instance is ready
   useEffect(() => {
@@ -127,8 +124,6 @@ export default function VisualizeRowReact({
   useEffect(() => {
     setProblemData([]);
     setCurrentProblemData(null);
-    setShowSolutionCircuit(false);
-    setHasSolutionCircuit(false);
   }, [problemName, problemInstance, chosenVisualization]);
 
   // Fetch reduction visualization
@@ -169,42 +164,20 @@ export default function VisualizeRowReact({
 
         if (!alive) return;
 
-        let processedData = [];
+        let processedData = data ? [...data] : [];
 
-        if (Array.isArray(data)) {
-          processedData = [...data];
-        } else if (data?.steps && Array.isArray(data.steps)) {
-          processedData = data.steps.map((frame) => ({
-            ...frame,
-            metadata: { ...(data.metadata || {}), ...(frame?.metadata || {}) },
-          }));
-        } else if (data) {
-          processedData = [data];
+        // In reduction mode, only show the first and last frames to highlight the delta
+        if (showReduction && processedData.length > 1) {
+          processedData = [
+            processedData[0],
+            processedData[processedData.length - 1],
+          ];
         }
-
-        if (showReduction && list.length > 1) {
-          list = [list[0], list[list.length - 1]];
-        }
-
-
-        const hasSolution = processedData.some(
-          (frame) => frame && Array.isArray(frame.solutionCircuit) && frame.solutionCircuit.length > 0
-        );
 
         setProblemData(processedData);
         setCurrentProblemData(processedData?.[0] ?? null);
-        setHasSolutionCircuit(hasSolution);
-        setShowSolutionCircuit((prev) => hasSolution ? prev : false);
       } catch (err) {
         console.error(err);
-        if (isCurrent) {
-          setProblemData([]);
-          setProblemReductionData([]);
-          setCurrentProblemData(null);
-          setCurrentReductionData(null);
-          setHasSolutionCircuit(false);
-          setShowSolutionCircuit(false);
-        }
       }
     };
 
@@ -288,15 +261,11 @@ export default function VisualizeRowReact({
     setShowReduction(e.target.checked);
     setCurrentStep(0);
   }
-  function handleSolutionCircuitChange(e) {
-    setShowSolutionCircuit(e.target.checked && hasSolutionCircuit);
-  }
   function handleRefreshButton() {
     setSvgIsLoading(false);
     setShowSolution(false);
     setShowGadgets(false);
     setShowReduction(false);
-    setShowSolutionCircuit(false);
     setCurrentStep(0);
   }
 
@@ -446,7 +415,6 @@ export default function VisualizeRowReact({
               label={SWITCHES.switch2}
               onChange={handleSwitch2Change}
             />
-            <FormControlLabel disabled={disableSolutionCircuit} checked={showSolutionCircuit} control={<Switch id="showSolutionCircuit" />} label="Show solution circuit" onChange={handleSolutionCircuitChange} />
             <FormControlLabel
               disabled={disableSolution}
               checked={showSolution}
@@ -498,7 +466,6 @@ export default function VisualizeRowReact({
           reductionData={currentReductionData}
           showSolutionToggle={showSolution}
           reductionVisualization={reductionVisualization}
-          showSolutionCircuit={showSolutionCircuit}
         />
       </ProblemSection.Body>
     </ProblemSection>

--- a/components/widgets/VisualizationLogic.js
+++ b/components/widgets/VisualizationLogic.js
@@ -24,7 +24,6 @@ export default function VisualizationLogic({
   reductionData,
   reductionVisualization,
   chosenReduceTo,
-  showSolutionCircuit = false,
 }) {
   const [gadgetMap, setGadgetMap] = useState([]);
   let visualization;
@@ -48,14 +47,14 @@ export default function VisualizationLogic({
 
   if (url && problemInstance && problemData && Object.keys(problemData).length > 0) {
     try {
-      visualization = Visualizations.get(visualizationType)(solve, url, problemData, gadgetMap, visualizationState.gadgetsOn, { showSolutionCircuit })
+      visualization = Visualizations.get(visualizationType)(solve, url, problemData, gadgetMap, visualizationState.gadgetsOn)
     } catch {
       visualization = <No_Viz_Svg niceProblemName={problemNameMap.get(problemName)} />
     }
 
     if (visualizationState.reductionOn) {
       try {
-        reducedVisualization = Visualizations.get(reductionVisualization)(solve, url, reductionData, gadgetMap, visualizationState.gadgetsOn, { showSolutionCircuit })
+        reducedVisualization = Visualizations.get(reductionVisualization)(solve, url, reductionData, gadgetMap, visualizationState.gadgetsOn)
 
         //NOTE - Caleb, The following is a temporary fix until CLIQUE_SVG_REACT.js is fixed, currently it takes the 3sat instance, 
         // but should take the clique instance, once that is fixed the following code block should be able to be removed without issue


### PR DESCRIPTION
Removed the unfinished/unused solution-circuit toggle that might have caused inconsistent behavior across visualizations:

- Dropped showSolutionCircuit state/UI/prop in components/pageblocks/VisualizeRowReact.js, stopped forwarding it through components/widgets/VisualizationLogic.js, and removed the extra arg/prop passthrough in components/Visualization/svgs/Visualizations.js.

- Restored the simple processedData = data ? [...data] : [] handling in VisualizeRowReact (no steps/metadata expansion)

- Restored reduction-mode to show only the first/last frames when showReduction is on. (might have been cause for issues for other visualizations and reductions)