### PR TITLE
About Us: replace hardcoded contributor list with live API fetch + clickable profile modal

### DIFF
--- a/pages/aboutus/index.js
+++ b/pages/aboutus/index.js
@@ -1,11 +1,11 @@
 import ResponsiveAppBar from "../../components/widgets/ResponsiveAppBar";
-import { createTheme, ThemeProvider, Container, Box, Button, Collapse } from "@mui/material";
+import { createTheme, ThemeProvider, Container, Box, Button, Dialog, DialogTitle, DialogContent, DialogActions, IconButton } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { Card } from "react-bootstrap";
 import isulogo from "../../components/images/ISULogo.png";
 import Image from "next/image";
 import { useState, useEffect } from "react";
-import Link from "next/link";
 
 export default function AboutUsPage() {
   const theme = createTheme({
@@ -17,32 +17,14 @@ export default function AboutUsPage() {
   });
 
   const cardBodyStyle = { padding: "20px" };
+  
+  // State management
   const [contributorData, setContributorData] = useState({});
+  const [selectedContributor, setSelectedContributor] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  // Fetch contributor metadata from backend
-  useEffect(() => {
-    const fetchAllContributorData = async () => {
-      const dataMap = {};
-      
-      for (const name of contributors) {
-        try {
-          const encodedName = encodeURIComponent(name);
-          const response = await fetch(`https://api.redux.portneuf.cose.isu.edu/Navigation/ContributorProfile/${encodedName}`);
-          if (response.ok) {
-            const data = await response.json();
-            dataMap[name] = data;
-          }
-        } catch (error) {
-          console.warn(`Failed to fetch data for ${name}:`, error);
-        }
-      }
-      
-      setContributorData(dataMap);
-    };
-    
-    fetchAllContributorData();
-  }, []);
-
+  // Contributors array defined FIRST
   const contributors = [
     "Kaden Marchetti",
     "Caleb Eardley",
@@ -63,39 +45,77 @@ export default function AboutUsPage() {
     "George Lake",
     "Grant Gardner",
     "Jason Wright",
-    "Alex Svancara", 
-    "Eric Hill", 
-    "Max Grünwoldt", 
+    "Alex Svancara",
+    "Eric Hill",
+    "Max Grünwoldt",
     "Paul Gilbreath",
     "Andreas Kramer",
     "Courtney Bodily",
     "Rakesh Itani"
   ];
 
+  // Fetch all contributor data on mount
+  useEffect(() => {
+    const fetchAllContributorData = async () => {
+      const dataMap = {};
+      
+      for (const name of contributors) {
+        try {
+          const encodedName = encodeURIComponent(name);
+          const response = await fetch(`http://localhost:27000/Navigation/ContributorProfile/${encodedName}`);
+          if (response.ok) {
+            const data = await response.json();
+            dataMap[name] = data;
+          }
+        } catch (error) {
+          console.warn(`Failed to fetch data for ${name}:`, error);
+        }
+      }
+      
+      setContributorData(dataMap);
+    };
+    
+    fetchAllContributorData();
+  }, []);
+
+  // Handle contributor click - open modal
+  const handleContributorClick = (name) => {
+    setLoading(true);
+    setSelectedContributor(name);
+    
+    // Simulate loading if data already cached
+    setTimeout(() => {
+      setLoading(false);
+      setModalOpen(true);
+    }, 300);
+  };
+
+  // Close modal
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setSelectedContributor(null);
+    setLoading(false);
+  };
+
   const publications = [
     {
-      title:
-        "R. Phillips and P. M. Bodily, “Spade: A library for programmatic parsing and verification of discrete data structures,” in 2025 Intermountain Engineering, Technology and Computing (IETC), pp. 1–5, IEEE, 2025.",
+      title: "R. Phillips and P. M. Bodily, Spade: A library for programmatic parsing and verification of discrete data structures, in 2025 Intermountain Engineering, Technology and Computing (IETC), pp. 1–5, IEEE, 2025.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11039449",
     },
     {
-      title:
-        "K. Marchetti, A. Sevaljevic, A. Diviney, R. Phillips, C. Eardley, R. Khadka, D. Igbokwe, and P. M. Bodily, “Redux: An interactive, dynamic knowledge base for teaching NP-completeness,” in Proceedings of the 29th annual ACM conference on Innovation and Technology in Computer Science Education (ITiCSE), 2024.",
+      title: "K. Marchetti, A. Sevaljevic, A. Diviney, R. Phillips, C. Eardley, R. Khadka, D. Igbokwe, and P. M. Bodily, Redux: An interactive, dynamic knowledge base for teaching NP-completeness, in Proceedings of the 29th annual ACM conference on Innovation and Technology in Computer Science Education (ITiCSE), 2024.",
       link: "https://etd.iri.isu.edu/ViewSpecimen.aspx?ID=2206",
     },
     {
-      title:
-        "A. Sevaljevic and P. M. Bodily, “Comparative empirical analysis of dancing links implementations to solve the exact cover problem,” in Proceedings of the 4th Intermountain Engineering, Technology, and Computing Conference (i-ETC), pp. 255–258, IEEE, 2024.",
+      title: "A. Sevaljevic and P. M. Bodily, Comparative empirical analysis of dancing links implementations to solve the exact cover problem, in Proceedings of the 4th Intermountain Engineering, Technology, and Computing Conference (i-ETC), pp. 255–258, IEEE, 2024.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=10564396",
     },
     {
-      title:
-        'K. Marchetti and P. Bodily, "Visualizing the 3SAT to CLIQUE Reduction Process," 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-5, doi: 10.1109/IETC54973.2022.9796851.',
+      title: "K. Marchetti and P. Bodily, Visualizing the 3SAT to CLIQUE Reduction Process, 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-5, doi: 10.1109/IETC54973.2022.9796851.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=9796851",
     },
     {
-      title:
-        'K. Marchetti and P. Bodily, "KAMI: Leveraging the power of crowd-sourcing to solve complex, real-world problems," 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-4, doi: 10.1109/IETC54973.2022.9796945.',
+      title: "K. Marchetti and P. Bodily, KAMI: Leveraging the power of crowd-sourcing to solve complex, real-world problems, 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-4, doi: 10.1109/IETC54973.2022.9796945.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9796945",
     },
   ];
@@ -118,7 +138,7 @@ export default function AboutUsPage() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              &quot;Reducibility Among Combinatorial Problems&quot;
+              {"Reducibility Among Combinatorial Problems"}
             </a>{" "}
             {"(Karp, 1972)."}
           </Card.Body>
@@ -187,18 +207,19 @@ export default function AboutUsPage() {
               }}
             >
               {contributors.map((name, index) => {
-                const data = contributorData[name];
-                const nameSlug = name.replace(/\s+/g, '-').toLowerCase();
-                
                 return (
                   <div key={index}>
-                    • <Link href={`/contributor/${nameSlug}`} legacyBehavior>
-                      <a 
-                        style={{ color: "#f47920", textDecoration: "underline", cursor: "pointer" }}
-                      >
-                        {name}
-                      </a>
-                    </Link>
+                    • <span
+                      onClick={() => handleContributorClick(name)}
+                      style={{ 
+                        color: "#f47920", 
+                        textDecoration: "underline", 
+                        cursor: "pointer",
+                        fontWeight: "500"
+                      }}
+                    >
+                      {name}
+                    </span>
                   </div>
                 );
               })}
@@ -206,23 +227,23 @@ export default function AboutUsPage() {
           </Card.Body>
         </Card>
 
-                    {/* LEARN MORE Card */}
-                    <Card>
-                        <Card.Header><b>Learn More</b></Card.Header>
-                        <Card.Body style={cardBodyStyle}>
-                            {`Additional documentation can be found at the following links:`}
-                            <ul>
-                                <li><a href="https://github.com/ReduxISU/" target="_blank" rel="noopener noreferrer">Github</a></li>
-                                <li><a href="https://en.wikipedia.org/wiki/NP-completeness" target="_blank" rel="noopener noreferrer">Wikipedia: What is NP-Complete?</a></li>
-                                <li><a href="https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf" target="_blank" rel="noopener noreferrer">Karp&apos;s 21 NP-Complete Problems</a></li>
-                                <li><a href="https://github.com/ReduxISU/Redux_GUI/blob/ReduxAPI_GUI/Documentation/index.md" target="_blank" rel="noopener noreferrer">Redux GUI Documentation</a></li>
-                                <li><a href="https://github.com/ReduxISU/Redux/blob/CSharpAPI/Documentation/index.md" target="_blank" rel="noopener noreferrer">Redux Backend Documentation</a></li>
-                                <li><a href="https://api.redux.portneuf.cose.isu.edu/swagger/index.html" target="_blank" rel="noopener noreferrer">API Swagger Documentation</a></li>
+        {/* LEARN MORE Card */}
+        <Card>
+          <Card.Header><b>Learn More</b></Card.Header>
+          <Card.Body style={cardBodyStyle}>
+            {`Additional documentation can be found at the following links:`}
+            <ul>
+              <li><a href="https://github.com/ReduxISU/" target="_blank" rel="noopener noreferrer">Github</a></li>
+              <li><a href="https://en.wikipedia.org/wiki/NP-completeness" target="_blank" rel="noopener noreferrer">Wikipedia: What is NP-Complete?</a></li>
+              <li><a href="https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf" target="_blank" rel="noopener noreferrer">Karp's 21 NP-Complete Problems</a></li>
+              <li><a href="https://github.com/ReduxISU/Redux_GUI/blob/ReduxAPI_GUI/Documentation/index.md" target="_blank" rel="noopener noreferrer">Redux GUI Documentation</a></li>
+              <li><a href="https://github.com/ReduxISU/Redux/blob/CSharpAPI/Documentation/index.md" target="_blank" rel="noopener noreferrer">Redux Backend Documentation</a></li>
+              <li><a href="http://localhost:27000/swagger/index.html" target="_blank" rel="noopener noreferrer">API Swagger Documentation (Local)</a></li>
+            </ul>
+          </Card.Body>
+        </Card>
+      </Container>
 
-                            </ul>
-                        </Card.Body>
-                    </Card>
-                </Container>
       {/* ISU Logo */}
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="10vh">
         <a
@@ -233,6 +254,81 @@ export default function AboutUsPage() {
           <Image src={isulogo} alt="ISU Logo" height={125} width={500} />
         </a>
       </Box>
+
+      {/* Contributor Profile Modal */}
+      <Dialog open={modalOpen} onClose={handleCloseModal} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {selectedContributor && `${selectedContributor}'s Profile`}
+          <IconButton
+            aria-label="close"
+            onClick={handleCloseModal}
+            sx={{
+              position: 'absolute',
+              right: 8,
+              top: 8,
+              color: (theme) => theme.palette.grey[500],
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          {loading ? (
+            <p>Loading...</p>
+          ) : selectedContributor && contributorData[selectedContributor] ? (
+            <div>
+              <h5 style={{ marginBottom: '15px' }}>Personal Information</h5>
+              <p><strong>Email:</strong> {contributorData[selectedContributor].email || "Not specified"}</p>
+              <p><strong>Education:</strong> {contributorData[selectedContributor].education || "Not specified"}</p>
+              <p><strong>Major:</strong> {contributorData[selectedContributor].major || "Not specified"}</p>
+              <p><strong>Bio:</strong> {contributorData[selectedContributor].bio || "Not specified"}</p>
+              
+              <h5 style={{ marginTop: '20px', marginBottom: '15px' }}>Contributions</h5>
+              <p><strong>Total Contributions:</strong> {contributorData[selectedContributor].totalContributions || 0}</p>
+              
+              {contributorData[selectedContributor].problemsContributed && contributorData[selectedContributor].problemsContributed.length > 0 && (
+                <div>
+                  <strong>Problems:</strong> {contributorData[selectedContributor].problemsContributed.length}
+                  <ul>
+                    {contributorData[selectedContributor].problemsContributed.map((problem, idx) => (
+                      <li key={idx}>{problem}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              
+              {contributorData[selectedContributor].solversCreated && contributorData[selectedContributor].solversCreated.length > 0 && (
+                <div>
+                  <strong>Solvers:</strong> {contributorData[selectedContributor].solversCreated.length}
+                  <ul>
+                    {contributorData[selectedContributor].solversCreated.map((solver, idx) => (
+                      <li key={idx}>{solver}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              
+              {contributorData[selectedContributor].reductionsCreated && contributorData[selectedContributor].reductionsCreated.length > 0 && (
+                <div>
+                  <strong>Reductions:</strong> {contributorData[selectedContributor].reductionsCreated.length}
+                  <ul>
+                    {contributorData[selectedContributor].reductionsCreated.map((reduction, idx) => (
+                      <li key={idx}>{reduction}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p>No data found</p>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseModal} color="primary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
     </ThemeProvider>
   );
 }

--- a/pages/aboutus/index.js
+++ b/pages/aboutus/index.js
@@ -1,11 +1,24 @@
 import ResponsiveAppBar from "../../components/widgets/ResponsiveAppBar";
-import { createTheme, ThemeProvider, Container, Box, Button, Dialog, DialogTitle, DialogContent, DialogActions, IconButton } from "@mui/material";
+import {
+  createTheme,
+  ThemeProvider,
+  Container,
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+} from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import 'bootstrap/dist/css/bootstrap.min.css';
+import "bootstrap/dist/css/bootstrap.min.css";
 import { Card } from "react-bootstrap";
 import isulogo from "../../components/images/ISULogo.png";
 import Image from "next/image";
 import { useState, useEffect } from "react";
+
+const reduxBaseUrl = process.env.NEXT_PUBLIC_REDUX_BASE_URL;
 
 export default function AboutUsPage() {
   const theme = createTheme({
@@ -17,105 +30,74 @@ export default function AboutUsPage() {
   });
 
   const cardBodyStyle = { padding: "20px" };
-  
-  // State management
-  const [contributorData, setContributorData] = useState({});
+
+  const [contributors, setContributors] = useState([]);
+  const [githubMap, setGithubMap] = useState({});
   const [selectedContributor, setSelectedContributor] = useState(null);
+  const [profileData, setProfileData] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  // Contributors array defined FIRST
-  const contributors = [
-    "Kaden Marchetti",
-    "Caleb Eardley",
-    "Daniel Igbokwe",
-    "Alex Diviney",
-    "Janita Aamir",
-    "Andrija Sevaljevic",
-    "Garret Stouffer",
-    "Porter Glines",
-    "Show Pratoomratana",
-    "Russell Phillips",
-    "Michael Crapse",
-    "Ian Gonzalez",
-    "Sabal Subedi",
-    "Himanshu Jha",
-    "Sansar Kharal",
-    "Pratham Khanal",
-    "George Lake",
-    "Grant Gardner",
-    "Jason Wright",
-    "Alex Svancara",
-    "Eric Hill",
-    "Max Grünwoldt",
-    "Paul Gilbreath",
-    "Andreas Kramer",
-    "Courtney Bodily",
-    "Rakesh Itani"
-  ];
-
-  // Fetch all contributor data on mount
   useEffect(() => {
-    const fetchAllContributorData = async () => {
-      const dataMap = {};
-      
-      for (const name of contributors) {
-        try {
-          const encodedName = encodeURIComponent(name);
-          const response = await fetch(`http://localhost:27000/Navigation/ContributorProfile/${encodedName}`);
-          if (response.ok) {
-            const data = await response.json();
-            dataMap[name] = data;
-          }
-        } catch (error) {
-          console.warn(`Failed to fetch data for ${name}:`, error);
+    fetch(`${reduxBaseUrl}Navigation/ContributorProfile/directory`)
+      .then((r) => r.json())
+      .then((entries) => {
+        setContributors(entries.map((e) => e.name));
+        const map = {};
+        for (const entry of entries) {
+          if (entry.githubUsername) map[entry.name] = entry.githubUsername;
         }
-      }
-      
-      setContributorData(dataMap);
-    };
-    
-    fetchAllContributorData();
+        setGithubMap(map);
+      })
+      .catch(() => {});
   }, []);
 
-  // Handle contributor click - open modal
   const handleContributorClick = (name) => {
     setLoading(true);
     setSelectedContributor(name);
-    
-    // Simulate loading if data already cached
-    setTimeout(() => {
-      setLoading(false);
-      setModalOpen(true);
-    }, 300);
+    setProfileData(null);
+    setModalOpen(true);
+
+    fetch(`${reduxBaseUrl}Navigation/ContributorProfile/${encodeURIComponent(name)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        setProfileData(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
   };
 
-  // Close modal
   const handleCloseModal = () => {
     setModalOpen(false);
     setSelectedContributor(null);
+    setProfileData(null);
     setLoading(false);
   };
 
   const publications = [
     {
-      title: "R. Phillips and P. M. Bodily, Spade: A library for programmatic parsing and verification of discrete data structures, in 2025 Intermountain Engineering, Technology and Computing (IETC), pp. 1–5, IEEE, 2025.",
+      title:
+        "R. Phillips and P. M. Bodily, Spade: A library for programmatic parsing and verification of discrete data structures, in 2025 Intermountain Engineering, Technology and Computing (IETC), pp. 1–5, IEEE, 2025.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11039449",
     },
     {
-      title: "K. Marchetti, A. Sevaljevic, A. Diviney, R. Phillips, C. Eardley, R. Khadka, D. Igbokwe, and P. M. Bodily, Redux: An interactive, dynamic knowledge base for teaching NP-completeness, in Proceedings of the 29th annual ACM conference on Innovation and Technology in Computer Science Education (ITiCSE), 2024.",
+      title:
+        "K. Marchetti, A. Sevaljevic, A. Diviney, R. Phillips, C. Eardley, R. Khadka, D. Igbokwe, and P. M. Bodily, Redux: An interactive, dynamic knowledge base for teaching NP-completeness, in Proceedings of the 29th annual ACM conference on Innovation and Technology in Computer Science Education (ITiCSE), 2024.",
       link: "https://etd.iri.isu.edu/ViewSpecimen.aspx?ID=2206",
     },
     {
-      title: "A. Sevaljevic and P. M. Bodily, Comparative empirical analysis of dancing links implementations to solve the exact cover problem, in Proceedings of the 4th Intermountain Engineering, Technology, and Computing Conference (i-ETC), pp. 255–258, IEEE, 2024.",
+      title:
+        "A. Sevaljevic and P. M. Bodily, Comparative empirical analysis of dancing links implementations to solve the exact cover problem, in Proceedings of the 4th Intermountain Engineering, Technology, and Computing Conference (i-ETC), pp. 255–258, IEEE, 2024.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=10564396",
     },
     {
-      title: "K. Marchetti and P. Bodily, Visualizing the 3SAT to CLIQUE Reduction Process, 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-5, doi: 10.1109/IETC54973.2022.9796851.",
+      title:
+        "K. Marchetti and P. Bodily, Visualizing the 3SAT to CLIQUE Reduction Process, 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-5, doi: 10.1109/IETC54973.2022.9796851.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=9796851",
     },
     {
-      title: "K. Marchetti and P. Bodily, KAMI: Leveraging the power of crowd-sourcing to solve complex, real-world problems, 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-4, doi: 10.1109/IETC54973.2022.9796945.",
+      title:
+        "K. Marchetti and P. Bodily, KAMI: Leveraging the power of crowd-sourcing to solve complex, real-world problems, 2022 Intermountain Engineering, Technology and Computing (IETC), Orem, UT, USA, 2022, pp. 1-4, doi: 10.1109/IETC54973.2022.9796945.",
       link: "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9796945",
     },
   ];
@@ -126,47 +108,30 @@ export default function AboutUsPage() {
       <Container>
         <br />
 
-        {/* ABOUT US Card */}
+        {/* ABOUT US */}
         <Card>
-          <Card.Header>
-            <b>About Us</b>
-          </Card.Header>
+          <Card.Header><b>About Us</b></Card.Header>
           <Card.Body style={cardBodyStyle}>
             {"Welcome to Redux, a platform for NP-Complete problems. Input your challenges and gain access to reductions, solutions, verifiers, and visualizations. Join our community of problem solvers and unravel computational complexities using the application's library. The project was greatly inspired by Richard Karp's paper "}
-            <a
-              href="https://doi.org/10.1007/978-1-4684-2001-2_9"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {"Reducibility Among Combinatorial Problems"}
+            <a href="https://doi.org/10.1007/978-1-4684-2001-2_9" target="_blank" rel="noopener noreferrer">
+              Reducibility Among Combinatorial Problems
             </a>{" "}
-            {"(Karp, 1972)."}
+            (Karp, 1972).
           </Card.Body>
         </Card>
 
         <br />
 
-        {/* PUBLICATIONS Card */}
+        {/* PUBLICATIONS */}
         <Card>
-          <Card.Header>
-            <b>Publications</b>
-          </Card.Header>
+          <Card.Header><b>Publications</b></Card.Header>
           <Card.Body style={cardBodyStyle}>
-            <p>
-              Below are research publications associated with the Redux project
-              and its contributors:
-            </p>
+            <p>Below are research publications associated with the Redux project and its contributors:</p>
             <ul>
               {publications.map((pub, index) => (
                 <li key={index} style={{ marginBottom: "10px" }}>
                   {pub.title}{" "}
-                  <a
-                    href={pub.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    [PDF]
-                  </a>
+                  <a href={pub.link} target="_blank" rel="noopener noreferrer">[PDF]</a>
                 </li>
               ))}
             </ul>
@@ -175,70 +140,51 @@ export default function AboutUsPage() {
 
         <br />
 
-        {/* CONTRIBUTORS Card */}
+        {/* CONTRIBUTORS */}
         <Card>
-          <Card.Header>
-            <b>Contributors</b>
-          </Card.Header>
+          <Card.Header><b>Contributors</b></Card.Header>
           <Card.Body style={cardBodyStyle}>
             <p>
               This project was started by Dr.{" "}
-              <a
-                href="https://www2.cose.isu.edu/~bodipaul/index.php"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://www2.cose.isu.edu/~bodipaul/index.php" target="_blank" rel="noopener noreferrer">
                 Paul Bodily
               </a>
               , who is also the ISU Faculty Sponsor of the project.
             </p>
-            <p>
-              The students who contributed to the creation of the application
-              are:
-            </p>
+            <p>The students who contributed to the creation of the application are:</p>
 
-            {/* Column-ordered 3-column layout */}
-            <div
-              style={{
-                columnCount: 3,
-                columnGap: "40px",
-                paddingLeft: "20px",
-                lineHeight: "1.6",
-              }}
-            >
-              {contributors.map((name, index) => {
-                return (
-                  <div key={index}>
-                    • <span
-                      onClick={() => handleContributorClick(name)}
-                      style={{ 
-                        color: "#f47920", 
-                        textDecoration: "underline", 
-                        cursor: "pointer",
-                        fontWeight: "500"
-                      }}
-                    >
-                      {name}
-                    </span>
-                  </div>
-                );
-              })}
+            <div style={{ columnCount: 3, columnGap: "40px", paddingLeft: "20px", lineHeight: "1.6" }}>
+              {contributors.map((name, index) => (
+                <div key={index}>
+                  •{" "}
+                  <span
+                    onClick={() => handleContributorClick(name)}
+                    onMouseEnter={(e) => (e.target.style.color = "#ff9a40")}
+                    onMouseLeave={(e) => (e.target.style.color = "#f47920")}
+                    style={{ color: "#f47920", textDecoration: "underline", cursor: "pointer", fontWeight: "500" }}
+                  >
+                    {name}
+                  </span>
+                </div>
+              ))}
             </div>
           </Card.Body>
         </Card>
 
-        {/* LEARN MORE Card */}
+        <br />
+
+        {/* LEARN MORE */}
         <Card>
           <Card.Header><b>Learn More</b></Card.Header>
           <Card.Body style={cardBodyStyle}>
-            {`Additional documentation can be found at the following links:`}
+            Additional documentation can be found at the following links:
             <ul>
               <li><a href="https://github.com/ReduxISU/" target="_blank" rel="noopener noreferrer">Github</a></li>
               <li><a href="https://en.wikipedia.org/wiki/NP-completeness" target="_blank" rel="noopener noreferrer">Wikipedia: What is NP-Complete?</a></li>
               <li><a href="https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf" target="_blank" rel="noopener noreferrer">Karp's 21 NP-Complete Problems</a></li>
               <li><a href="https://github.com/ReduxISU/Redux_GUI/blob/ReduxAPI_GUI/Documentation/index.md" target="_blank" rel="noopener noreferrer">Redux GUI Documentation</a></li>
               <li><a href="https://github.com/ReduxISU/Redux/blob/CSharpAPI/Documentation/index.md" target="_blank" rel="noopener noreferrer">Redux Backend Documentation</a></li>
-              <li><a href="http://localhost:27000/swagger/index.html" target="_blank" rel="noopener noreferrer">API Swagger Documentation (Local)</a></li>
+              <li><a href={`${reduxBaseUrl}swagger/index.html`} target="_blank" rel="noopener noreferrer">API Swagger Documentation</a></li>
             </ul>
           </Card.Body>
         </Card>
@@ -246,75 +192,81 @@ export default function AboutUsPage() {
 
       {/* ISU Logo */}
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="10vh">
-        <a
-          href="https://www.isu.edu/cs/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://www.isu.edu/cs/" target="_blank" rel="noopener noreferrer">
           <Image src={isulogo} alt="ISU Logo" height={125} width={500} />
         </a>
       </Box>
 
       {/* Contributor Profile Modal */}
       <Dialog open={modalOpen} onClose={handleCloseModal} maxWidth="sm" fullWidth>
-        <DialogTitle>
+        <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          {githubMap[selectedContributor] && (
+            <img
+              src={`https://github.com/${githubMap[selectedContributor]}.png`}
+              alt={selectedContributor}
+              style={{ width: 48, height: 48, borderRadius: "50%", border: "2px solid #f47920" }}
+            />
+          )}
           {selectedContributor && `${selectedContributor}'s Profile`}
           <IconButton
             aria-label="close"
             onClick={handleCloseModal}
-            sx={{
-              position: 'absolute',
-              right: 8,
-              top: 8,
-              color: (theme) => theme.palette.grey[500],
-            }}
+            sx={{ position: "absolute", right: 8, top: 8, color: (t) => t.palette.grey[500] }}
           >
             <CloseIcon />
           </IconButton>
         </DialogTitle>
+
         <DialogContent dividers>
           {loading ? (
             <p>Loading...</p>
-          ) : selectedContributor && contributorData[selectedContributor] ? (
+          ) : profileData ? (
             <div>
-              <h5 style={{ marginBottom: '15px' }}>Personal Information</h5>
-              <p><strong>Email:</strong> {contributorData[selectedContributor].email || "Not specified"}</p>
-              <p><strong>Education:</strong> {contributorData[selectedContributor].education || "Not specified"}</p>
-              <p><strong>Major:</strong> {contributorData[selectedContributor].major || "Not specified"}</p>
-              <p><strong>Bio:</strong> {contributorData[selectedContributor].bio || "Not specified"}</p>
-              
-              <h5 style={{ marginTop: '20px', marginBottom: '15px' }}>Contributions</h5>
-              <p><strong>Total Contributions:</strong> {contributorData[selectedContributor].totalContributions || 0}</p>
-              
-              {contributorData[selectedContributor].problemsContributed && contributorData[selectedContributor].problemsContributed.length > 0 && (
+              <h5 style={{ marginBottom: "15px" }}>Personal Information</h5>
+              <p><strong>Email:</strong> {profileData.email || "Not specified"}</p>
+              <p><strong>Education:</strong> {profileData.education || "Not specified"}</p>
+              <p><strong>Major:</strong> {profileData.major || "Not specified"}</p>
+              <p><strong>Bio:</strong> {profileData.bio || "Not specified"}</p>
+
+              {githubMap[selectedContributor] && (
+                <p>
+                  <strong>GitHub: </strong>
+                  <a
+                    href={`https://github.com/${githubMap[selectedContributor]}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {`github.com/${githubMap[selectedContributor]}`}
+                  </a>
+                </p>
+              )}
+
+              <h5 style={{ marginTop: "20px", marginBottom: "15px" }}>Contributions</h5>
+              <p><strong>Total Contributions:</strong> {profileData.totalContributions || 0}</p>
+
+              {profileData.problemsContributed?.length > 0 && (
                 <div>
-                  <strong>Problems:</strong> {contributorData[selectedContributor].problemsContributed.length}
+                  <strong>Problems:</strong> {profileData.problemsContributed.length}
                   <ul>
-                    {contributorData[selectedContributor].problemsContributed.map((problem, idx) => (
-                      <li key={idx}>{problem}</li>
-                    ))}
+                    {profileData.problemsContributed.map((p, i) => <li key={i}>{p}</li>)}
                   </ul>
                 </div>
               )}
-              
-              {contributorData[selectedContributor].solversCreated && contributorData[selectedContributor].solversCreated.length > 0 && (
+
+              {profileData.solversCreated?.length > 0 && (
                 <div>
-                  <strong>Solvers:</strong> {contributorData[selectedContributor].solversCreated.length}
+                  <strong>Solvers:</strong> {profileData.solversCreated.length}
                   <ul>
-                    {contributorData[selectedContributor].solversCreated.map((solver, idx) => (
-                      <li key={idx}>{solver}</li>
-                    ))}
+                    {profileData.solversCreated.map((s, i) => <li key={i}>{s}</li>)}
                   </ul>
                 </div>
               )}
-              
-              {contributorData[selectedContributor].reductionsCreated && contributorData[selectedContributor].reductionsCreated.length > 0 && (
+
+              {profileData.reductionsCreated?.length > 0 && (
                 <div>
-                  <strong>Reductions:</strong> {contributorData[selectedContributor].reductionsCreated.length}
+                  <strong>Reductions:</strong> {profileData.reductionsCreated.length}
                   <ul>
-                    {contributorData[selectedContributor].reductionsCreated.map((reduction, idx) => (
-                      <li key={idx}>{reduction}</li>
-                    ))}
+                    {profileData.reductionsCreated.map((r, i) => <li key={i}>{r}</li>)}
                   </ul>
                 </div>
               )}
@@ -323,10 +275,9 @@ export default function AboutUsPage() {
             <p>No data found</p>
           )}
         </DialogContent>
+
         <DialogActions>
-          <Button onClick={handleCloseModal} color="primary">
-            Close
-          </Button>
+          <Button onClick={handleCloseModal} color="primary">Close</Button>
         </DialogActions>
       </Dialog>
     </ThemeProvider>

--- a/pages/aboutus/index.js
+++ b/pages/aboutus/index.js
@@ -1,9 +1,11 @@
 import ResponsiveAppBar from "../../components/widgets/ResponsiveAppBar";
-import { createTheme, ThemeProvider, Container, Box } from "@mui/material";
-import "bootstrap/dist/css/bootstrap.min.css";
+import { createTheme, ThemeProvider, Container, Box, Button, Collapse } from "@mui/material";
+import 'bootstrap/dist/css/bootstrap.min.css';
 import { Card } from "react-bootstrap";
 import isulogo from "../../components/images/ISULogo.png";
 import Image from "next/image";
+import { useState, useEffect } from "react";
+import Link from "next/link";
 
 export default function AboutUsPage() {
   const theme = createTheme({
@@ -15,6 +17,31 @@ export default function AboutUsPage() {
   });
 
   const cardBodyStyle = { padding: "20px" };
+  const [contributorData, setContributorData] = useState({});
+
+  // Fetch contributor metadata from backend
+  useEffect(() => {
+    const fetchAllContributorData = async () => {
+      const dataMap = {};
+      
+      for (const name of contributors) {
+        try {
+          const encodedName = encodeURIComponent(name);
+          const response = await fetch(`https://api.redux.portneuf.cose.isu.edu/Navigation/ContributorProfile/${encodedName}`);
+          if (response.ok) {
+            const data = await response.json();
+            dataMap[name] = data;
+          }
+        } catch (error) {
+          console.warn(`Failed to fetch data for ${name}:`, error);
+        }
+      }
+      
+      setContributorData(dataMap);
+    };
+    
+    fetchAllContributorData();
+  }, []);
 
   const contributors = [
     "Kaden Marchetti",
@@ -159,9 +186,22 @@ export default function AboutUsPage() {
                 lineHeight: "1.6",
               }}
             >
-              {contributors.map((name, index) => (
-                <div key={index}>• {name}</div>
-              ))}
+              {contributors.map((name, index) => {
+                const data = contributorData[name];
+                const nameSlug = name.replace(/\s+/g, '-').toLowerCase();
+                
+                return (
+                  <div key={index}>
+                    • <Link href={`/contributor/${nameSlug}`} legacyBehavior>
+                      <a 
+                        style={{ color: "#f47920", textDecoration: "underline", cursor: "pointer" }}
+                      >
+                        {name}
+                      </a>
+                    </Link>
+                  </div>
+                );
+              })}
             </div>
           </Card.Body>
         </Card>


### PR DESCRIPTION
## What this PR does

The About Us page previously had a hardcoded array of 26 contributor names baked directly into the frontend source code. This meant that every time a new student joined the project, someone had to manually edit `pages/aboutus/index.js`, commit it, and redeploy the frontend — just to get a name to show up on the page.

This PR removes that hardcoded array entirely and replaces it with a live fetch from the backend. It also adds a clickable profile modal so visitors can see a contributor's personal info, GitHub profile, and contribution breakdown without leaving the page.

---

## The problem with the old approach

```js
// Old code — every new contributor required a frontend code change
const contributors = [
  "Kaden Marchetti",
  "Caleb Eardley",
  // ... 24 more names hardcoded here
];
```

This created an unnecessary coupling between the contributor list and the frontend codebase. It also meant the list could silently fall out of date if someone forgot to update it.

---

## What changed

### 1. Contributor names are now fetched from the backend

On page load, a single call goes to:

```
GET /Navigation/ContributorProfile/directory
```

This endpoint returns an array of entries like `{ name, githubUsername }`. The component extracts the names for the list and builds a `githubMap` (name → GitHub username) for use in the modal. No more hardcoded array.

### 2. Profiles load lazily — only when you click a name

Previously, the page was firing off 26 individual API calls on mount to pre-fetch every contributor's full profile data. Now nothing is fetched until a user actually clicks a name. This makes the initial page load significantly lighter.

```js
// Profile fetch is triggered only on click
const handleContributorClick = (name) => {
  fetch(`${reduxBaseUrl}Navigation/ContributorProfile/${encodeURIComponent(name)}`)
    ...
};
```

### 3. Clickable contributor names open a profile modal

Each name in the contributors list is now a styled, clickable link (orange, underlined, with a hover lighten effect). Clicking it opens a MUI Dialog showing:

- Email, education, major, and bio
- A GitHub profile link (if `githubUsername` is present in the JSON)
- A GitHub avatar pulled from `github.com/<username>.png`
- Contribution counts broken down by problems, solvers, and reductions

### 4. API base URL uses the environment variable

All fetch calls use `process.env.NEXT_PUBLIC_REDUX_BASE_URL`, which is already configured in `.env.development` (`http://localhost:27000/`) and `.env.production` (`https://api.redux.portneuf.cose.isu.edu/`). The previously hardcoded `localhost:27000` URL and the hardcoded Swagger link in Learn More are both fixed.

---

## How the new contributor flow works

1. A new contributor adds their entry to `contributorInfo.json` on the backend
2. Backend is restarted
3. Their name automatically appears on the About Us page — no frontend changes needed

---

## Files changed

- `pages/aboutus/index.js` — only file changed

---

## Testing done

- Built locally with `npm run build` — no errors
- Ran the dev server and verified contributor names load from the API
- Clicked several contributor names and confirmed the modal opens with correct data
- Verified the modal closes cleanly and resets state on each open/close
- Confirmed the page renders an empty list gracefully when the backend is unreachable (the `.catch(() => {})` swallows the error silently)

---

## Reviewer notes

- This PR depends on the backend exposing a `GET /Navigation/ContributorProfile/directory` endpoint that returns `[{ name: string, githubUsername?: string }]`. Please confirm this route exists and is deployed before merging.
- The GitHub avatar (`github.com/<username>.png`) is loaded directly from GitHub's CDN — no auth needed, but it will silently show nothing if the username is wrong or the user has no avatar set.