### PR TITLE
feat: honor delay field on graph nodes and edges for staggered animations

### DIFF
--- a/components/Visualization/svgs/StandardGraphSvgReact.js
+++ b/components/Visualization/svgs/StandardGraphSvgReact.js
@@ -127,30 +127,65 @@ function ForceGraph({ w, h, charge, problemData, gadgetMap }) {
       }
     });
 
-    // Draw links
+    // Helper: parse the delay attribute (string from backend) into a positive
+    // number of milliseconds. Returns 0 for missing / non-numeric / non-positive
+    // values, which means "render at final color immediately, no animation."
+    const getDelayMs = d => {
+      const n = parseInt(d?.delay, 10);
+      return Number.isFinite(n) && n > 0 ? n : 0;
+    };
+    const FADE_DURATION_MS = 500;
+
+    // Draw links. If a link has a positive delay, start it at the default edge
+    // color and transition to its final color after the delay. This produces a
+    // staggered animation for visualizations like Topological Sort that color
+    // edges in waves by topological rank.
     const link = svg.selectAll("line")
       .data(data.links)
       .join("line")
       .attr("marker-end", d => d.directed ? `url(#${d.markerId})` : null)
-      .style("stroke", d => getColorByKey(d.color || "Edges"))
+      .style("stroke", d => getDelayMs(d) > 0
+        ? getColorByKey("Edges")
+        : getColorByKey(d.color || "Edges"))
       .style("stroke-width", "2px")
       .style("stroke-dasharray", d => d.dashed ? "5,5" : "none");
 
+    link.filter(d => getDelayMs(d) > 0 && d.color)
+      .transition()
+      .delay(d => getDelayMs(d))
+      .duration(FADE_DURATION_MS)
+      .style("stroke", d => getColorByKey(d.color));
+
+    // Draw arrowhead markers for directed edges. Match the link's animation so
+    // the arrow color stays in sync with its line.
     problemData.links?.forEach(d => {
       if (d.directed) {
         const markerPath = d3.select(`#${d.markerId} path`);
-        markerPath.attr("fill", getColorByKey(d.color || "Edges"));
+        const delayMs = getDelayMs(d);
+        if (delayMs > 0 && d.color) {
+          markerPath.attr("fill", getColorByKey("Edges"))
+            .transition()
+            .delay(delayMs)
+            .duration(FADE_DURATION_MS)
+            .attr("fill", getColorByKey(d.color));
+        } else {
+          markerPath.attr("fill", getColorByKey(d.color || "Edges"));
+        }
       }
     });
 
-    // Draw nodes
+    // Draw nodes. Same delay-aware pattern as links: nodes with a positive
+    // delay start at the background color and animate to their final color
+    // after the delay.
     const node = svg.selectAll("circle")
       .data(data.nodes)
       .join("circle")
       .attr("r", 20)
       .attr("id", d => "id" + d.id.replace("!", "NOT"))
       .attr("class", d => "node" + d.id.replace("!", "NOT"))
-      .attr("fill", d => getColorByKey(d.color || "Background"))
+      .attr("fill", d => getDelayMs(d) > 0
+        ? getColorByKey("Background")
+        : getColorByKey(d.color || "Background"))
       .attr("stroke", d => d.outline ? getColorByKey(d.outline) : null)
       .attr("stroke-width", d => d.outline ? 2 : 0)
       .on("mouseover", (event, d) => {
@@ -165,6 +200,12 @@ function ForceGraph({ w, h, charge, problemData, gadgetMap }) {
           clearHighlights(d.id, gadgetMap);
         }
       });
+
+    node.filter(d => getDelayMs(d) > 0 && d.color)
+      .transition()
+      .delay(d => getDelayMs(d))
+      .duration(FADE_DURATION_MS)
+      .attr("fill", d => getColorByKey(d.color));
 
     // Draw labels
     const text = svg.selectAll("text")


### PR DESCRIPTION
# feat: honor `delay` field on graph nodes and edges for staggered animations

## Context

This PR is the frontend half of a two-PR change that addresses review feedback on a backend contribution.

**Backend PR:** [ReduxISU/Redux#194 — fix: address review feedback on Topological Sort (PR #178)](https://github.com/ReduxISU/Redux/pull/194)

The reviewer (@Andrija-Sevaljevic) on the original Topological Sort merge ([Redux#178](https://github.com/ReduxISU/Redux/pull/178)) flagged the visualization as not making logical sense for the problem and suggested either removing it or implementing a new template on the front-end:

> Visualization - I would remove it or implement a new template for it on the front-end. It does not logically make sense to visualize the problem this way.

This frontend PR enables a meaningful animated visualization for Topological Sort (and any other graph problem that wants stepped animation) by making the existing D3 renderer honor the backend's `delay` field instead of discarding it. This unblocks the rank-based animation implemented in the backend PR.

---

## Problem

The C# backend has, for a long time, populated a `delay` field on nodes and links returned by graph-style visualizations:

```json
{ "name": "2", "color": "Solution", "delay": "1250", ... }
```

But the frontend D3 renderer in [`StandardGraphSvgReact.js`](components/Visualization/svgs/StandardGraphSvgReact.js) painted every color statically with `.attr("fill", ...)` / `.style("stroke", ...)` and **never read the `delay` field**. A repository-wide search for `delay`, `transition`, `setTimeout`, or `animate` in `components/` and `pages/` returned zero matches.

The effect: every backend visualization that set `delay` (DirectedHamiltonian, ShortestPath, Topological Sort, etc.) was producing dead round-trip data. Solutions appeared instantly with no temporal cue, even when the algorithm being visualized is fundamentally about ordering or progression.

## Fix

Updated `StandardGraphSvgReact.js` so the D3 renderer honors `delay` via transitions:

1. **`getDelayMs(d)` helper** — safely parses the backend's string `delay` into a positive number of ms. Returns `0` for missing, empty, non-numeric, or non-positive values, which the rest of the code treats as "render at final color immediately, no animation."

2. **Links** — if `delay > 0`, start at the default `Edges` color, then `.transition().delay(delayMs).duration(500).style("stroke", finalColor)`.

3. **Arrowhead markers on directed links** — same animation as their parent link, so heads stay color-synced with the line.

4. **Nodes** — if `delay > 0`, start at `Background`, then transition to `d.color` after the delay.

5. **Constant `FADE_DURATION_MS = 500`** controls the smoothness of the fade-in for all transitioning elements.

## Backwards compatibility

- Visualizations that **do not set** `delay` (or set it to `0` / `""` / non-numeric) render exactly as before — same colors, same timing.
- Visualizations that **do** set `delay` now animate. This includes `DirectedHamiltonian` and `ShortestPath`, which were already setting delays that the frontend silently discarded — they get the upgrade for free.
- No new dependencies; uses D3 transitions that are already loaded.
- No API surface changes; the `problemData` shape is unchanged.

## Verification

Tested locally with the backend PR #194 against several instances:

| Test | Backend instance | Observed in GUI |
|---|---|---|
| Topological Sort default | `({1,2,3,4,5,6},{(1,2),(1,3),(2,4),(3,4),(4,5),(3,6)})` | Wave 0 (Node 1) at 0 s; wave 1 (Nodes 2, 3) at 1.25 s; wave 2 (Nodes 4, 6) at 2.5 s; wave 3 (Node 5) at 3.75 s — exactly matches the rank-based delays the backend computed |
| Topological Sort cyclic | `({1,2,3},{(1,2),(2,3),(3,1)})` | Solver returns `{}`; visualize returns un-highlighted graph; no animation triggered (correct) |
| DirectedHamiltonian | default instance | Now animates the path step-by-step (previously rendered statically) |
| Visualization with no `delay` | other graph problems | Renders exactly as before, no behavioral change |

## Test plan

- [x] Topological Sort animates in waves matching backend rank computation
- [x] Cyclic Topological Sort instance does not trigger a phantom animation
- [x] DirectedHamiltonian visualization gains expected step-by-step animation
- [x] Graph visualizations that don't set `delay` are visually unchanged
- [x] No console errors or D3 warnings during transitions

## Team

- **Pravesh Aryal** — frontend animation fix
- **Dinesh Khanal**, **Koras Koirala** — backend rank-based visualization (companion PR #194)
