### PR TITLE
Use generic mapSolution + SipserReduceToSAT3 instead of reverseMappedSolution

### DIFF
--- a/components/redux/index.js
+++ b/components/redux/index.js
@@ -408,8 +408,8 @@ export async function requestSolvedInstanceTemporarySat3CliqueSolver(url, solver
     }
 
     const mappedSolution = await fetchPostJson(
-      `${url}SipserReduceToCliqueStandard/reverseMappedSolution`,
-      { problemFrom: instance, problemTo: reduction.reductionTo.instance, problemFromSolution: solution },
+      `${url}ProblemProvider/mapSolution?reduction=SipserReduceToSAT3&solution=${encodeURIComponent(solution)}`,
+      reduction.reductionTo.instance,
       () => "TRANSITIVE SOLVED REQUEST FAILED"
     );
 


### PR DESCRIPTION
In `requestSolvedInstanceTemporarySat3CliqueSolver` (components/redux/index.js), switch the "map the clique back to a 3SAT assignment" call from the per-reduction SAT3 controller endpoint `SipserReduceToCliqueStandard/reverseMappedSolution` to the generic `ProblemProvider/mapSolution` route, dispatched via the inverse reduction class `SipserReduceToSAT3`. Body shape changes from the three-field {problemFrom, problemTo, problemFromSolution} envelope to a plain instance string, matching how every other call site in this file uses the generic mapSolution route.

This is the GUI half of the cleanup tracked by ReduxISU/Redux#214. It removes the only remaining caller of reverseMappedSolution, after which the Redux C# repo can delete the endpoint, its controller route, and the orphaned reverseMapSolutions method on `SipserReduceToCliqueStandard`. The Redux C# side will need both PRs in flight before either is reviewed safely: this PR alone leaves reverseMappedSolution unused but still defined; the C# deletion PR alone would break this GUI call site if merged first. Suggested order: merge this PR, then the C# deletion PR.

~~The new call requires `SipserReduceToSAT3` to exist in the running Redux C# backend, which it does on the clique-to-sat3 branch (ReduxISU/Redux#213).~~ (done)