### PR TITLE
fix: make NEXT_PUBLIC_REDUX_BASE_URL configurable at Docker build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ COPY . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
+ARG NEXT_PUBLIC_REDUX_BASE_URL=https://api.redux.portneuf.cose.isu.edu/
+ENV NEXT_PUBLIC_REDUX_BASE_URL=$NEXT_PUBLIC_REDUX_BASE_URL
+
 RUN yarn build
 
 # If using npm comment out above and use below instead


### PR DESCRIPTION
## Summary

- Adds a `NEXT_PUBLIC_REDUX_BASE_URL` build ARG to the Dockerfile so the API base URL can be overridden per deployment without modifying source files
- Defaults to the existing ISU API URL (`https://api.redux.portneuf.cose.isu.edu/`) so all existing builds are unaffected

## Usage

Default build (uses ISU URL):
```bash
docker buildx build --load -t redux-gui .
```

Custom API URL:
```bash
docker buildx build \
  --load \
  --build-arg NEXT_PUBLIC_REDUX_BASE_URL=https://your-api-host/ \
  -t redux-gui .
```

## Test plan

- [ ] Build without `--build-arg` and verify app connects to the ISU API
- [ ] Build with `--build-arg NEXT_PUBLIC_REDUX_BASE_URL=https://your-api-host/` and verify app connects to the overridden URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)