### PR TITLE
chore: bump Docker actions and add top-level workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - ReduxAPI_GUI
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - ReduxAPI_GUI
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,14 +35,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- `docker/login-action`: v3 → v4 (latest: v4.2.0)
- `docker/build-push-action`: v6 → v7 (latest: v7.2.0)
- Add top-level `permissions` block to `publish.yml` (`contents: read`, `packages: write`) and `main.yml` (`contents: read`) to follow least-privilege best practices

## Test plan
- [ ] Verify the `docker publish` workflow passes on merge to `ReduxAPI_GUI`
- [ ] Verify the `main` build workflow passes on merge to `ReduxAPI_GUI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)