### PR TITLE
chore: bump actions/checkout to v6 in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`


### PR DESCRIPTION
## Summary
- `actions/checkout`: v4 → v6 (latest: v6.0.3) in `codeql.yml`

All other actions in the workflow files were already on their latest major versions.

## Test plan
- [ ] Verify CodeQL workflow passes on merge to `ReduxAPI_GUI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)