### PR TITLE
chore: enable Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to enable weekly Dependabot updates for:
- npm packages
- GitHub Actions

## Test plan
- [ ] Confirm Dependabot PRs appear in the repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)