### PR TITLE
chore: remove dead SipserReduceToCliqueStandard solver path

### DIFF
--- a/components/hooks/ProblemProvider/Solver.js
+++ b/components/hooks/ProblemProvider/Solver.js
@@ -14,13 +14,7 @@ export function useSolver(url, problemName, problemType, problemNameMap, problem
 }
 
 export function useSolverInfo(url, solver) {
-  // NOTE - Caleb - the following is a temporary solution to allow sat3 to be solved using the clique solver
-  // remove first if once this functionality is added for all problems, the false expression was the original
-  // functionality
-  return useGenericInfo(
-    url,
-    solver === "CliqueBruteForce - via SipserReduceToCliqueStandard" ? "CliqueBruteForce" : solver
-  );
+  return useGenericInfo(url, solver);
 }
 
 function useSolvedInstance(problemInstance, chosenSolver) {

--- a/components/pageblocks/SolveRowReact.js
+++ b/components/pageblocks/SolveRowReact.js
@@ -14,7 +14,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import { Button } from "@mui/material";
 import { Download as DownloadIcon } from '@mui/icons-material';
 
-import { requestSolvedInstanceTemporarySat3CliqueSolver } from "../redux";
+import { requestSolvedInstance } from "../redux";
 import PopoverTooltipClick from "../widgets/PopoverTooltipClick";
 import { useSolverInfo } from "../hooks/ProblemProvider";
 import ProblemSection from "../widgets/ProblemSection";
@@ -48,7 +48,7 @@ export default function SolveRowReact({
   async function handleSolve() {
     setSolvedInstance(
       chosenSolver && problemInstance
-        ? (await requestSolvedInstanceTemporarySat3CliqueSolver(url, chosenSolver, problemInstance)) ?? ""
+        ? (await requestSolvedInstance(url, chosenSolver, problemInstance)) ?? ""
         : ""
     );
   }

--- a/components/redux/index.js
+++ b/components/redux/index.js
@@ -386,61 +386,6 @@ export async function requestSolvedInstance(url, solver, instance) {
 }
 
 /**
- * Temporary solution to allow solving 3 SAT with a Clique solver.
- * All calls to this function should eventually be replace with `requestSolvedInstance`.
- * A verbose name was purposefully chosen as a reminder to fix this.
- * @returns the solved `instance` from the specified `solver`.
- * @returns `undefined` on failure and logs the error.
- */
-export async function requestSolvedInstanceTemporarySat3CliqueSolver(url, solver, instance) {
-  // NOTE - Caleb - the following is a temporary solution to allow sat3 to be solved using the clique solver
-  // remove first if once this functionality is added for all problems, the else code block was the original
-  // functionality
-  if (solver == "CliqueBruteForce - via SipserReduceToCliqueStandard") {
-    const reduction = await requestReducedInstance(url, "SipserReduceToCliqueStandard", instance);
-    if (!reduction) {
-      return undefined;
-    }
-
-    const solution = await requestSolvedInstance(url, "CliqueBruteForce", reduction.reductionTo.instance);
-    if (!solution) {
-      return undefined;
-    }
-
-    const mappedSolution = await fetchPostJson(
-      `${url}ProblemProvider/mapSolution?reduction=SipserReduceToSAT3&solution=${encodeURIComponent(solution)}`,
-      reduction.reductionTo.instance,
-      () => "TRANSITIVE SOLVED REQUEST FAILED"
-    );
-
-    return mappedSolution;
-  } else {
-    return await requestSolvedInstance(url, solver, instance);
-  }
-}
-
-/**
- * @returns the solved graph visualization of the problem instance.
- * @returns `undefined` on failure and logs the error.
- */
-export async function requestSolvedVisualization(url, problem, instance, solution) {
-  // TODO: convert to POST request for problem instance
-  var preparedSolution = solution.replaceAll("&", "%26");
-  var preparedInstance = instance.replaceAll("&", "%26");
-  if (problem == "SipserReduceToCliqueStandard") {
-    return await fetchJson(
-      `${url}${problem}/solvedVisualization?problemInstance=${preparedInstance}&solution=${preparedSolution}`,
-      () => `${problem} VISUALIZE REQUEST FAILED`
-    );
-  } else {
-    return await fetchJson(
-      `${url}${problem}Generic/solvedVisualization?problemInstance=${preparedInstance}&solution=${preparedSolution}`,
-      () => `${problem} VISUALIZE REQUEST FAILED`
-    );
-  }
-}
-
-/**
  * @returns the `steps` from the specified `solver`.
  * @returns `undefined` on failure and logs the error.
  */


### PR DESCRIPTION
## Summary

- Deletes `requestSolvedInstanceTemporarySat3CliqueSolver` from `components/redux/index.js` — the `"CliqueBruteForce - via SipserReduceToCliqueStandard"` branch was unreachable because the backend endpoint (`Nav_Solvers.cs`) that would have surfaced that solver option is commented out.
- Deletes `requestSolvedVisualization` from `components/redux/index.js` — never imported or called anywhere in the frontend.
- Replaces the import and call site in `components/pageblocks/SolveRowReact.js` with `requestSolvedInstance` directly (same signature, was the else-branch anyway).
- Removes the dead ternary and comment block in `components/hooks/ProblemProvider/Solver.js` (`useSolverInfo`), passing `solver` straight to `useGenericInfo`.

The `SipserReduceToCliqueStandard` reduction itself (Reduce row when 3SAT is selected) is untouched.

**3 insertions, 64 deletions.**

## Test plan

- [ ] Select a problem with a solver and confirm Solve still works end-to-end.
- [ ] Confirm the Reduce row for 3SAT → Clique (SipserReduceToCliqueStandard) still functions normally.
- [ ] Confirm no build/lint errors (`npm run build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)