### PR TITLE
ci: only run docker publish on upstream repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'ReduxISU/Redux_GUI'
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The `docker publish` workflow triggers on every push to `ReduxAPI_GUI`, including on forks. This gates the workflow on `github.repository` so it only runs in `ReduxISU/Redux_GUI`.

- Added `if: github.repository == 'ReduxISU/Redux_GUI'` to the `build` job.
- The `publish` job has `needs: build`, so it skips automatically on forks.

This also avoids the publish failing on forks, where `GITHUB_TOKEN` lacks write access to the upstream package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)