### PR TITLE
feat: display edge weight labels on weighted graphs in StandardGraphSvgReact.js

### DIFF
--- a/components/Visualization/svgs/StandardGraphSvgReact.js
+++ b/components/Visualization/svgs/StandardGraphSvgReact.js
@@ -209,8 +209,20 @@ function ForceGraph({ w, h, charge, problemData, gadgetMap }) {
       .duration(FADE_DURATION_MS)
       .attr("fill", d => getColorByKey(d.color));
 
+    // Draw edge weight labels for weighted graphs (MaxCut, MinSTCut, etc.)
+    const linkLabel = svg.selectAll(".link-label")
+      .data(data.links.filter(d => d.weighted))
+      .enter()
+      .append("text")
+      .attr("class", "link-label")
+      .attr("fill", "black")
+      .attr("font-size", "11px")
+      .attr("text-anchor", "middle")
+      .style("pointer-events", "none")
+      .text(d => d.weight);
+
     // Draw labels
-    const text = svg.selectAll("text")
+    const text = svg.selectAll("text:not(.link-label)")
       .data(data.nodes)
       .enter()
       .append("text")
@@ -249,6 +261,11 @@ function ForceGraph({ w, h, charge, problemData, gadgetMap }) {
       node
         .attr("cx", d => d.x)
         .attr("cy", d => d.y);
+
+      linkLabel
+        .attr("x", d => (d.source.x + d.target.x) / 2)
+        .attr("y", d => (d.source.y + d.target.y) / 2)
+        .attr("dy", -4);
 
       text
         .attr("x", d => d.x)


### PR DESCRIPTION
…vgReact

Add a D3 linkLabel selection that filters links where d.weighted is true and appends <text> elements at each edge midpoint showing d.weight. Labels are positioned in ticked() to track the force simulation. Fixes the node label selector to use text:not(.link-label) so the two text layers don't interfere. No backend changes required — weight and weighted fields are already present in the MaxCut and MinSTCut API responses.