### PR TITLE
chore: remove dead solution-mapping and solver-steps functions

### DIFF
--- a/components/redux/index.js
+++ b/components/redux/index.js
@@ -290,57 +290,6 @@ export async function requestReductionVisualization(url, reduction, solution, in
   );
 }
 
-export async function processReductionVisualizations(url, reductionPath, instance) {
-  const reductions = reductionPath.split("-").map(r => r.trim());
-
-  let currentInstance = instance;
-  let solution = requestSolvedInstance(url, solver, currentInstance)
-  let finalVisualization = null;
-
-  for (const reduction of reductions) {
-    finalVisualization = await requestReductionVisualization(url, reduction, currentInstance, solution);
-    const info = await requestInfo(url, reduction, instance);
-    currentInstance = info.reductionTo.defaultInstance;
-    solution = requestMappedSolution(url, solution, currentInstance);
-  }
-
-  return finalVisualization;
-}
-
-/**
- * @param reductionPath a hyphen (`-`) separated list of reductions to perform on the instance.
- */
-export async function requestMappedSolutionTransitive(url, reductionPath, problemInstance, solution) {
-  let problemFrom = problemInstance;
-  let mappedSolution = solution;
-  for (const reduction of reductionPath.split("-")) {
-    const reduced = await requestReducedInstance(url, reduction, problemFrom);
-    if (!reduced) {
-      console.log(`${reductionPath} AT ${reduction} REDUCTION FOR SOLUTION MAPPING REQUEST FAILED`);
-      break;
-    }
-    const problemTo = reduced.reductionTo.instance;
-
-    const solution = await requestMappedSolution(url, reduction, problemFrom, problemTo, mappedSolution);
-    if (!solution) {
-      console.log("SOLUTION MAPPING REQUEST FAILED");
-      break;
-    }
-    mappedSolution = solution;
-
-    problemFrom = problemTo;
-  }
-  return mappedSolution;
-}
-
-export async function requestMappedSolution(url, reduction, problemFrom, problemTo, solution) {
-  return await fetchPostJson(
-    `${url}${reduction}/mapSolution`,
-    { problemFrom: problemFrom, problemTo: problemTo, problemFromSolution: solution },
-    () => `${reduction} MAPPED SOLUTION REQUEST FAILED`
-  );
-}
-
 /**
  * @returns an array of all implemented problems identifiers.
  * @returns `undefined` on failure and logs the error.

--- a/components/redux/index.js
+++ b/components/redux/index.js
@@ -335,18 +335,6 @@ export async function requestSolvedInstance(url, solver, instance) {
 }
 
 /**
- * @returns the `steps` from the specified `solver`.
- * @returns `undefined` on failure and logs the error.
- */
-export async function requestSolverSteps(url, solver, instance) {
-  return await fetchPostJson(
-    `${url}ProlemProvider/steps?solver=${solver}`,
-    instance,
-    () => `${solver} SOLVED INSTANCE REQUEST FAILED`
-  );
-}
-
-/**
  * @returns an array of solvers implemented for the `problem`.
  * @returns `undefined` on failure and logs the error.
  */


### PR DESCRIPTION
## Summary
Removes four exported functions from `components/redux/index.js` that have **no callers anywhere in the repo**:

- `processReductionVisualizations`
- `requestMappedSolutionTransitive`
- `requestMappedSolution`
- `requestSolverSteps`

`processReductionVisualizations` and `requestMappedSolutionTransitive` are never imported. `requestMappedSolution` was only reachable through those two, so all three are unreachable at runtime. `requestSolverSteps` likewise has no callers — and points at a misspelled route (`ProlemProvider`) with a copy-pasted error message, confirming it was never exercised. 63 lines removed.

## Verification
- Exhaustive search (`git grep` + ripgrep over the full tree, incl. untracked) confirms no references remain to any of the four names.
- No barrel re-exports, `import * as` namespace dispatch, or dynamic string dispatch could reach them — all consumers of this module use named imports.
- `eslint components/redux/index.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)