### PR TITLE
build: #119 add Biome formatter and improve ESLint

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm'
 
       - name: Install dependencies

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": [
+      "**",
+      "!public/**",
+      "!package-lock.json",
+      "!.next/**",
+      "!out/**",
+      "!build/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "linter": {
+    "enabled": false,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,93 @@
-const nextConfig = require("eslint-config-next/core-web-vitals");
+// ESLint flat config (ESLint 9+). CommonJS to match the repo (no "type":"module").
+//
+// Layering, applied in order — later entries win on conflicts:
+//   1. ignores        — vendored + build output we must NOT lint
+//   2. js.recommended — the base-JavaScript correctness floor (no-undef, no-unused-vars,
+//                       no-dupe-keys, no-unreachable, use-isnan, ...). eslint-config-next
+//                       does NOT include this, so without it the whole plain-JS bug class
+//                       goes unchecked. This is the coverage that was missing.
+//   3. next/core-web-vitals — React + React Hooks (incl. React-Compiler rules) + jsx-a11y
+//                       + @next/next, and 1000+ browser/node globals.
+//   4. import-x       — import-correctness (catches importing a name that doesn't exist).
+//                       See the long note below for why we use import-x, not Next's bundled
+//                       import plugin.
+//   5. project tuning — severity choices for THIS repo.
+//   6. eslint-config-prettier — MUST be last: turns off any stylistic rules so ESLint and
+//                       the Biome formatter never fight. Biome owns formatting; ESLint owns
+//                       correctness. No overlap.
+//
+// Blocking: the CI ESLint job is still report-only (continue-on-error) — findings surface in
+// GitHub code-scanning but do not fail PRs yet. Promoting a rule to a hard gate later is a
+// one-line change here (flip a "warn" to "error") plus removing continue-on-error in CI.
+//
+// WHY import-x INSTEAD OF Next's bundled eslint-plugin-import:
+//   Next ships a vendored eslint-plugin-import + eslint-module-utils whose default resolver is a
+//   TypeScript resolver. Under ESLint 9 flat config that resolver loads with an "invalid
+//   interface" and CRASHES the entire run the moment a resolver-dependent rule (import/named,
+//   import/no-unresolved) hits a file that imports a package. Overriding the resolver setting
+//   doesn't help because ESLint deep-merges `settings`, so Next's broken `typescript` resolver
+//   can't be removed by omission. eslint-plugin-import-x is the maintained, flat-config-native
+//   fork; we register it under its own `import-x/*` namespace with a node-only resolver (correct
+//   for this pure-JS repo) and leave Next's import rules untouched. This is dev-time only —
+//   Next 16's `next build` does not run ESLint, so none of this can affect the build or deploy.
 
-module.exports = nextConfig;
+const js = require("@eslint/js");
+const nextCoreWebVitals = require("eslint-config-next/core-web-vitals");
+const importX = require("eslint-plugin-import-x");
+const prettier = require("eslint-config-prettier");
+
+// eslint-config-next exports an array of flat-config objects; spread it in.
+const nextConfigs = Array.isArray(nextCoreWebVitals)
+  ? nextCoreWebVitals
+  : [nextCoreWebVitals];
+
+module.exports = [
+  // 1. Ignore what isn't ours. A config object with ONLY `ignores` is global.
+  //    public/ holds the vendored Q.js library + static assets — linting it produced 38
+  //    spurious no-undef errors, so it's excluded here.
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "public/**",
+      "next-env.d.ts",
+    ],
+  },
+
+  // 2. Base JavaScript correctness — the previously-missing floor.
+  js.configs.recommended,
+
+  // 3. Next.js / React / hooks / a11y / @next (existing coverage + globals).
+  ...nextConfigs,
+
+  // 4. Import correctness via import-x (see header note). Node resolver = correct for pure JS.
+  {
+    plugins: { "import-x": importX },
+    settings: {
+      "import-x/resolver": { node: { extensions: [".js", ".jsx", ".json"] } },
+    },
+    rules: {
+      // Imported a name the target module doesn't export (e.g. requestIsCertificateValid,
+      // Typograph). no-unused-vars can't catch these — they're imported AND used.
+      "import-x/named": "warn",
+      // Import path that doesn't resolve to a real module.
+      "import-x/no-unresolved": "warn",
+    },
+  },
+
+  // 5. Project-specific severity tuning.
+  {
+    rules: {
+      // Dead vars/imports are worth surfacing but there are ~100 today; keep them visible as
+      // warnings rather than a wall of errors while we're still non-blocking. Ratchet to
+      // "error" once the backlog is cleared.
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    },
+  },
+
+  // 6. Disable formatting-related rules so Biome (the formatter) is the single source of truth.
+  //    Keep LAST so it overrides anything stylistic enabled above.
+  prettier,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,11 @@
         "react-split": "^2.0.14"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.5.3",
         "eslint": "^9.0.0",
-        "eslint-config-next": "^16.2.6"
+        "eslint-config-next": "^16.2.6",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-import-x": "^4.17.1"
       },
       "engines": {
         "node": ">=26"
@@ -309,6 +312,181 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
+      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.3",
+        "@biomejs/cli-darwin-x64": "2.5.3",
+        "@biomejs/cli-linux-arm64": "2.5.3",
+        "@biomejs/cli-linux-arm64-musl": "2.5.3",
+        "@biomejs/cli-linux-x64": "2.5.3",
+        "@biomejs/cli-linux-x64-musl": "2.5.3",
+        "@biomejs/cli-win32-arm64": "2.5.3",
+        "@biomejs/cli-win32-x64": "2.5.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
+      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
+      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
+      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -3824,6 +4002,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5218,6 +5406,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
@@ -5290,6 +5519,56 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+      "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -8173,6 +8452,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "biome check --write .",
+    "format:check": "biome check .",
     "postinstall": "next telemetry disable"
   },
   "dependencies": {
@@ -32,7 +35,10 @@
     "react-split": "^2.0.14"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.3",
     "eslint": "^9.0.0",
-    "eslint-config-next": "^16.2.6"
+    "eslint-config-next": "^16.2.6",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import-x": "^4.17.1"
   }
 }


### PR DESCRIPTION
# Harden ESLint + add Biome (formatter-only)

**Branch:** `feature/119-hardened-eslint-rules-and-biome-for-formatting` → `develop`
**Repo:** Redux_GUI

---

## ⚠️ Read this first — scope guardrails

This PR is **plumbing to support future quality gates. It does not turn any gate on, and it does
not reformat any code.**

- **No blocking.** CI's ESLint job stays report-only (`continue-on-error: true`). Nothing in this
  PR can fail a build or block a merge. Flipping to blocking is a deliberate, separate decision.
- **The formatter has NOT been run.** `biome.json` is added, but `npm run format` was **not**
  executed — **zero source files are reformatted** in this PR. The repo-wide format sweep is a
  separate, isolated commit for later, kept out of here on purpose so this change stays reviewable.
- **No source / runtime changes.** The only files touched are config, CI, scripts, and the
  lockfile. App behavior is unchanged (verified — see [Verification](#verification)).

In short: this PR makes the linter *useful and honest*, and stages the formatter, **without
enforcing anything yet.** It lets us see what the tools would catch before we commit to gates.

---

## Why

The GUI's ESLint setup was a two-line passthrough of `eslint-config-next/core-web-vitals`, run in
CI with `continue-on-error: true`. Two problems:

1. **A whole layer of coverage was missing.** `next/core-web-vitals` layers React/Next/a11y rules
   on top of **nothing** — it does *not* include ESLint's base `recommended` set. So every core
   JavaScript correctness rule was off: `no-undef`, `no-unused-vars`, `no-dupe-keys`,
   `no-unreachable`, `use-isnan`, etc. The plain-JS bug class went completely unchecked. This
   matters more here than in most repos because **the GUI has no test suite at all** — ESLint is
   the only automated quality gate.
2. **The gate was theater.** With `continue-on-error`, the linter could report errors and CI
   stayed green regardless.

This PR fixes (1) and stages the tooling to fix (2) later.

---

## What changed

| File | Change |
|---|---|
| `eslint.config.js` | Two-line passthrough → explicit, hardened flat config (details below) |
| `biome.json` | **New.** Biome as **formatter only** (`linter.enabled: false`) |
| `package.json` | Added `lint:fix`, `format`, `format:check` scripts + 3 devDependencies |
| `package-lock.json` | Dependency resolutions for the new devDeps |
| `.github/workflows/code-analysis.yml` | ESLint job Node `22 → 26` (aligns with build/engines) |

New devDependencies (all dev-only): `@biomejs/biome`, `eslint-config-prettier`,
`eslint-plugin-import-x`.

### `eslint.config.js` — the layering

1. **ignores** — `node_modules`, `.next`, `out`, `build`, `public` (the vendored Q.js library +
   static assets — must not be linted), `next-env.d.ts`.
2. **`@eslint/js` recommended** — the previously-missing base-correctness floor.
3. **`next/core-web-vitals`** — the existing React / hooks / a11y / `@next` coverage + globals.
4. **`eslint-plugin-import-x`** — import correctness (`import-x/named`, `import-x/no-unresolved`)
   with a **node resolver** (correct for a pure-JS repo). See the note below on why import-x and
   not Next's bundled import plugin.
5. **project tuning** — `no-unused-vars` set to `warn` (there's a backlog; keep it visible, not a
   wall of blocking errors while we're non-blocking anyway).
6. **`eslint-config-prettier`** (last) — turns off stylistic rules so ESLint and the Biome
   formatter never fight. **ESLint owns correctness; Biome owns formatting. No overlap.**

**Why import-x instead of Next's bundled `eslint-plugin-import`:** Next ships a vendored
`eslint-plugin-import` whose default resolver is a TypeScript resolver. Under ESLint 9 flat config
that resolver loads with an "invalid interface" and **crashes the entire lint run** the moment a
resolver-dependent rule hits a file that imports a package. Overriding the resolver setting doesn't
help (ESLint deep-merges `settings`, so the broken `typescript` resolver can't be removed by
omission). `eslint-plugin-import-x` is the maintained, flat-config-native fork; we register it under
its own `import-x/*` namespace with a node-only resolver and leave Next's rules untouched. This is
dev-time only — **Next 16's `next build` does not run ESLint**, so none of it can affect the build
or deploy.

### `biome.json` — formatter only

- `formatter.enabled: true` (2-space, double quotes, semicolons, `lineWidth` 100) — matched to the
  existing code style.
- **`linter.enabled: false`** — Biome does **not** lint. ESLint remains the linter. The
  `recommended` ruleset is pre-wired but disabled, so adopting Biome's linter later (a *separate*,
  much-later decision) is a one-key flip.
- Import-organizing enabled (`assist.actions.source.organizeImports`).
- Excludes `public/**` and `package-lock.json` so a future sweep can never touch vendored or
  generated files.

---

## What this fixes / enables

**Real bugs surfaced immediately** (reported, not enforced — nothing blocks):

| Finding | Rule | Location |
|---|---|---|
| Duplicate object key `border` | `no-dupe-keys` | `components/Visualization/svgs/SSSPTableSvgReact.js:96` |
| Dead import — `requestIsCertificateValid` doesn't exist in `../redux` | `import-x/named` | `components/pageblocks/VerifyRowReact.js:17` |
| Dead import — `Typograph` doesn't exist in `@mui/material` | `import-x/named` | `pages/index.js:25` |
| Empty block | `no-empty` | (surfaced by base ruleset) |

The two dead imports are notable: they're imported **and referenced**, so `no-unused-vars` cannot
catch them — only import resolution does. These are exactly the class of latent bug the old config
was blind to.

**Also fixed / aligned:**
- The ESLint-9 import-plugin crash (via import-x) — the linter now runs cleanly to completion.
- CI Node inconsistency: the ESLint job was pinned to Node 22 while build + `engines` require 26.

**Foundation laid for future gates (explicitly out of scope for this PR):**
- Making lint **blocking**: flip `warn → error` on chosen rules + drop `continue-on-error`.
- The Biome **format sweep** + `format:check` in CI.

---

## Findings overview

`npm run lint` now reports **106 findings — 37 errors, 69 warnings.** None block (CI is
report-only). Breakdown:

| Count | Sev | Rule | New in this PR? |
|---:|:---:|---|---|
| 66 | warn | `no-unused-vars` | **Yes** (base floor) |
| 24 | error | `react-hooks/set-state-in-effect` | No — already flagged by old config |
| 10 | error | `react-hooks/immutability` | No — already flagged by old config |
| 2 | warn | `import-x/named` | **Yes** (import-x) |
| 1 | error | `no-dupe-keys` | **Yes** (base floor) |
| 1 | error | `no-empty` | **Yes** (base floor) |
| 1 | warn | `react-hooks/exhaustive-deps` | No |
| 1 | error | `react/jsx-no-duplicate-props` | No — already flagged by old config |

The 34 `react-hooks/*` errors are **pre-existing** (they come from `next/core-web-vitals` and were
already reported by the old config — just ignored by `continue-on-error`). This PR neither adds nor
fixes them; it leaves severity as-is. Whether/when to fix or downgrade them is a follow-up.

---

## Verification

The GUI has **no automated tests** (no test files, framework, config, or script — confirmed). So
verification was: dependency integrity, a production build, and a live end-to-end smoke test.

- **Dependencies** resolve cleanly; lockfile in sync (`npm install --dry-run` → "up to date").
- **Production build** passes on the final config (`next build` → exit 0, all 7 routes prerendered).
- **ESLint is decoupled from the build** — proven by building successfully *with a deliberately
  crashing ESLint config* on disk. Next 16 removed lint-during-build.
- **Live smoke test** (GUI dev server → proxy → backend), all green:
  - `/` renders (HTTP 200) with all five rows; `/aboutus` renders (200).
  - `info(SAT3)` → `3SAT`; `solve(SAT3)` → `(x1:True,x2:True,x3:False)`;
    `reduce(SAT3→CLIQUE)` → real CLIQUE instance; `visualize(CLIQUE)` → frames.

Conclusion: the tooling changes are inert to the running app; Redux behaves identically.

---

## How to try it (Node 26)

```bash
npm run lint          # 106 findings, no crash, nothing blocks
npm run lint:fix      # auto-fix the auto-fixable subset
npm run format:check  # DRY — shows what a format sweep would change (writes nothing)
# npm run format      # the sweep itself — NOT run in this PR; separate future commit
```

---

## Follow-ups (out of scope — do not expect them here)

1. **Run the Biome format sweep** as its own isolated commit once these tools are signed off.
2. **Make the gate blocking** (promote selected rules to `error`, remove `continue-on-error`,
   add `format:check` to CI) — pending sign-off on gates.
3. **Triage the surfaced findings** — fix the real bugs above; decide fix-vs-downgrade for the
   pre-existing `react-hooks/*` errors.
