### PR TITLE
fix: harden /api/redux proxy against SSRF (code-scanning #40)

### DIFF
--- a/pages/api/redux/[...path].js
+++ b/pages/api/redux/[...path].js
@@ -12,6 +12,26 @@ export default async function handler(req, res) {
   const suffix = req.url.replace(/^\/api\/redux\/?/, '');
   const targetUrl = `${baseUrl.replace(/\/$/, '')}/${suffix}`;
 
+  // Guard against SSRF: the user-controlled suffix must not be able to steer the
+  // request to a host/scheme other than the configured backend. Resolve the URL
+  // with the WHATWG parser and require it to stay on the backend's origin.
+  let target;
+  let base;
+  try {
+    target = new URL(targetUrl);
+    base = new URL(baseUrl);
+  } catch {
+    res.status(400).json({ error: 'Invalid request path' });
+    return;
+  }
+
+  const isSameOrigin = target.origin === base.origin;
+  const isAllowedScheme = target.protocol === 'http:' || target.protocol === 'https:';
+  if (!isSameOrigin || !isAllowedScheme) {
+    res.status(400).json({ error: 'Refusing to proxy request outside the configured backend' });
+    return;
+  }
+
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     if (!['host', 'connection', 'transfer-encoding'].includes(key.toLowerCase())) {
@@ -19,7 +39,10 @@ export default async function handler(req, res) {
     }
   }
 
-  const fetchOptions = { method: req.method, headers };
+  // Do not follow redirects server-side: a compromised or misbehaving backend
+  // could 3xx us toward an internal address (another SSRF path). Forward the
+  // redirect response to the client and let the browser decide what to do.
+  const fetchOptions = { method: req.method, headers, redirect: 'manual' };
 
   if (!['GET', 'HEAD'].includes(req.method)) {
     const chunks = [];
@@ -31,7 +54,7 @@ export default async function handler(req, res) {
 
   let upstream;
   try {
-    upstream = await fetch(targetUrl, fetchOptions);
+    upstream = await fetch(target, fetchOptions);
   } catch (err) {
     res.status(502).json({ error: `Upstream unreachable: ${err.message}` });
     return;


### PR DESCRIPTION
## What

Hardens the `/api/redux/*` proxy handler (`pages/api/redux/[...path].js`) against server-side request forgery:

- **Origin allowlist:** resolve the proxy target with the WHATWG `URL` parser and require it to stay on the configured backend's origin, with an `http:`/`https:` scheme, before calling `fetch`.
- **No server-side redirect following:** switch to `redirect: 'manual'` so a misbehaving/compromised backend can't `3xx` the *server* toward an internal address. The redirect is forwarded to the client instead.

## Which scan instance this fixes

Resolves code-scanning alert **[#40](https://github.com/ReduxISU/Redux_GUI/security/code-scanning/40)** — `js/request-forgery` (SSRF, critical), flagged at the `fetch(...)` call on `pages/api/redux/[...path].js:34` ("The URL of this request depends on a user-provided value").

## Note: not actually exploitable (but CodeQL couldn't prove it)

The prior code was **not** exploitable for host injection. The user-controlled suffix is appended *after* `"<baseUrl>/"`, so once the full string is parsed as a URL the authority stays pinned to the backend host — tested payloads (`https://evil.com/x`, `//evil.com/x`, `@evil.com/x`, backslash tricks) all resolved back to the backend origin. CodeQL flags it regardless because taint tracking can't prove that invariant.

This change makes the guarantee **explicit and machine-verifiable** (so the alert clears) and additionally closes the redirect-following vector, which *was* a real second SSRF path.

## Scope / not included

This does **not** restrict which backend *paths* or methods a client can reach — the proxy remains a full-surface passthrough to the backend origin. A path allowlist and Cookie/Authorization stripping were discussed as follow-up defense-in-depth but intentionally left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)