### PR TITLE
fix: remove empty try/catch in ProblemRowReact (code-scanning #78)

### DIFF
--- a/components/pageblocks/ProblemRowReact.js
+++ b/components/pageblocks/ProblemRowReact.js
@@ -134,9 +134,6 @@ export default function ProblemRowReact({ url, problemName, setProblemName, prob
 
   //Local state that handles problem instance change without triggering mass refreshing.
   const handleChangeInstance = (event) => {
-    try {
-    }
-    catch (error) { console.log("Couldn't clean problem instance: ", error); }
     setProblemLocalInstance(event.target.value)
     if (!instanceParsed.test) {
       defaultInstanceParsed.exampleStr = "";


### PR DESCRIPTION
## What

Removes a dead empty `try {} catch (error) { ... }` block in `handleChangeInstance` (`components/pageblocks/ProblemRowReact.js`). The `try` had no statements inside it, so the `catch` could never actually run — it wasn't guarding anything.

## Which scan instance this fixes

Resolves code-scanning alert **[#78](https://github.com/ReduxISU/Redux_GUI/security/code-scanning/78)** — `no-empty` (Disallow empty block statements), flagged at `components/pageblocks/ProblemRowReact.js:137-138`.

## Notes

The `storedData` variable a few lines above is also hardcoded to `null`, suggesting some localStorage read/write logic in this area was stripped out previously and this empty try/catch was left behind as a vestige. Left `storedData` alone since it's out of scope for this alert — flagging here in case it's worth a follow-up cleanup.

No behavior change: `setProblemLocalInstance(event.target.value)` and the rest of the handler still run exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)