### PR TITLE
Clean up some no-unused-vars warnings

### DIFF
--- a/components/Quantum/QuantumCircuitVisualizer.js
+++ b/components/Quantum/QuantumCircuitVisualizer.js
@@ -8,15 +8,12 @@ export default function QuantumCircuitVisualizer({ circuit }) {
 
   const [activeCircuit, setActiveCircuit] = useState(circuit);
   const svgWidth = "100%";
-  const [zoomLevel, setZoomLevel] = useState(1.0);
 
   const [gateType, setGateType] = useState("h");
   const [gateQubit, setGateQubit] = useState(0);
   const [gateTime, setGateTime] = useState(0);
   const [gateControl, setGateControl] = useState(0);
   const [gateTarget, setGateTarget] = useState(1);
-
-  const [selectedGate, setSelectedGate] = useState(null);
 
   const handleJSONImport = (event) => {
     const file = event.target.files[0];

--- a/components/Quantum/QuantumCircuitVisualizer.js
+++ b/components/Quantum/QuantumCircuitVisualizer.js
@@ -7,7 +7,7 @@ export default function QuantumCircuitVisualizer({ circuit }) {
   const svgRef = useRef();
 
   const [activeCircuit, setActiveCircuit] = useState(circuit);
-  const [svgWidth, setSvgWidth] = useState("100%");
+  const svgWidth = "100%";
   const [zoomLevel, setZoomLevel] = useState(1.0);
 
   const [gateType, setGateType] = useState("h");
@@ -207,7 +207,7 @@ export default function QuantumCircuitVisualizer({ circuit }) {
     }
 
     drawCircuit(activeCircuit);
-  }, [activeCircuit, svgWidth]);
+  }, [activeCircuit]);
 
   return (
     <div style={{ width: "100%", padding: "20px" }}>

--- a/components/Visualization/Graphvisualization.js
+++ b/components/Visualization/Graphvisualization.js
@@ -12,39 +12,7 @@ import dynamic from "next/dynamic";
 
 const Graphviz = dynamic(() => import("./GraphvizWrapper"), { ssr: false });
 
-
-const graphTest = `graph GRAPHCOLORING {  
-  node [style="filled"];  
-  a--b[ id="a-b"];
-  b--c[ id="b-c"]; 
-  c--a[ id="c-a"]; 
-  d--a[ id="d-a"]; 
-  d--e[ id="d-e"]; 
-  e--a[ id="e-a"]; 
-  f--a[ id="f-a"]; 
-  f--g[ id="f-g"]; 
-  a--g[ id="a-g"]; 
-  h--a[ id="h-a"]; 
-  h--i[ id="h-i"]; 
-  a--i[ id="a-i"]; 
-  a[fillcolor = White, id="a"] 
-  b[fillcolor = White, id="b"] 
-  c[fillcolor = White, id="c"] 
-  d[fillcolor = White, id="d"] 
-  e[fillcolor = White, id="e"] 
-  f[fillcolor = White, id="f"] 
-  g[fillcolor = White, id="g"] 
-  h[fillcolor = White, id="h"] 
-  i[fillcolor = White, id="i"] 
-   }`;
-
-
 function Page(props) {
-  let viz = "";
-  // const graphTest = props.dot;
-  //const [visualization, setVisualization]= useState('')
-
-
   return (
     <Graphviz dot={props.dot} options={props.options} />
 

--- a/components/Visualization/QuantumCircuitVis.js
+++ b/components/Visualization/QuantumCircuitVis.js
@@ -4,12 +4,7 @@ import { openqasmToQText } from "./openqasmToQText";
 
 const QuantumCircuitVis = ({
   problemData,
-  useSolutionCircuit = false,
-  // Unused today but kept for signature parity with other visualizations
-  solve,
-  url,
-  gadgetMap,
-  gadgetsOn,
+  useSolutionCircuit = false
 }) => {
   const [qReady, setQReady] = useState(false);
   const containerRef = useRef(null);

--- a/components/Visualization/openqasmToQText.js
+++ b/components/Visualization/openqasmToQText.js
@@ -146,7 +146,6 @@ export function openqasmToQText(qasm) {
         /^(gate_Q_[A-Za-z0-9_]+)\s+((?:q\[\d+\]\s*,\s*)*q\[\d+\]);$/
       ))
     ) {
-      const gateName = m[1];          // eg "gate_Q_4505047632" (not really used)
       const qubits = parseQubitList(m[2]); // [0,1,2,3,...]
 
       const symbol = "Q"; // our custom multi-qubit Grover gate symbol

--- a/components/widgets/ResponsiveAppBar.js
+++ b/components/widgets/ResponsiveAppBar.js
@@ -12,24 +12,16 @@ import {
     AppBar,
     Box,
     Toolbar,
-    IconButton,
     Typography,
-    Menu,
     Container,
-    Avatar,
     Button,
-    Tooltip,
-    MenuItem
 } from '@mui/material'; // Grouped all directory imports safely into a named root import
-import { Menu as MenuIcon, Adb as AdbIcon } from '@mui/icons-material'; // Grouped icons safely
+import { Adb as AdbIcon } from '@mui/icons-material'; // Grouped icons safely
 
 //const pages = ['Home', 'Tutorials', 'About Us', 'Navigation Graph'];
 const pages = ['Home', 'About Us']
 
-const ResponsiveAppBar = (props) => {
-    const [anchorElNav, setAnchorElNav] = React.useState(null);
-    const [anchorElUser, setAnchorElUser] = React.useState(null);
-
+const ResponsiveAppBar = () => {
     return (
         <AppBar position="static">
             <Container maxWidth="xl">

--- a/components/widgets/VisualizationLogic.js
+++ b/components/widgets/VisualizationLogic.js
@@ -16,14 +16,12 @@ export default function VisualizationLogic({
   reductionName,
   chosenReductionType,
   reductionNameMap,
-  reducedInstance,
   visualizationState,
   loading,
   visualizationType,
   problemData,
   reductionData,
   reductionVisualization,
-  chosenReduceTo,
 }) {
   const [gadgetMap, setGadgetMap] = useState([]);
   let visualization;
@@ -31,35 +29,30 @@ export default function VisualizationLogic({
 
   const solve = visualizationState.solverOn
 
-  const handleBar = (sizes) => { }
+  const handleBar = () => { }
 
-  const [loadingMap, setLoadingMap] = useState(false);
   const [mappedProblemData, setMappedProblemData] = useState(null);
   const [mappedReductionData, setMappedReductionData] = useState(null);
 
   useEffect(() => {
     if (problemInstance && problemData) {
-      setLoadingMap(true);
       processReductions(url, chosenReductionType, problemInstance)
         .then(rawGadgetMap => {
           const { gadgets, fromIdMap } = makeIdsUnique(rawGadgetMap);
           setGadgetMap(gadgets);
           setMappedProblemData(remapIdsDeep(problemData, fromIdMap) || problemData);
         })
-        .finally(() => setLoadingMap(false));
     }
   }, [problemData, url, chosenReductionType, problemInstance]);
 
 useEffect(() => {
   if (visualizationState.reductionOn && reductionVisualization && url && problemInstance) {
-    setLoadingMap(true);
     processReductions(url, chosenReductionType, problemInstance)
       .then(rawGadgetMap => {
         const { gadgets, toIdMap } = makeIdsUnique(rawGadgetMap);
         setGadgetMap(gadgets);
         setMappedReductionData(remapIdsDeep(reductionData, toIdMap) || reductionData);
       })
-      .finally(() => setLoadingMap(false));
   }
 }, [
   visualizationState.reductionOn,


### PR DESCRIPTION
## Summary

Works through a chunk of the `no-unused-vars` warnings ESLint surfaced (per #132's hardened base ruleset). Each commit is a self-contained, file-scoped fix:

- **QuantumCircuitVisualizer.js**: `svgWidth` state's setter was never called; converted to a plain constant.
- **VisualizationLogic.js**: `loadingMap` state was set but never read (write-only, no effect on rendering); `handleBar`'s `sizes` param was unused; `reducedInstance`/`chosenReduceTo` props were destructured but never referenced (the component uses `reductionData`/`problemInstance` and `chosenReductionType` instead).
- **ResponsiveAppBar.js**: `IconButton`, `Menu`, `Avatar`, `Tooltip`, `MenuItem`, `MenuIcon` imports and `anchorElNav`/`anchorElUser` state were leftovers from the mui.com template's mobile-nav and user-avatar menus, which this component never renders. The `props` parameter was also never read.
- **openqasmToQText.js**: removed a `gateName` variable explicitly commented `// not really used`.
- **Graphvisualization.js**: removed an unused `graphTest` constant, an unused `viz` variable, and stray commented-out dead code.
- **QuantumCircuitVis.js**: removed unused `solve`/`url`/`gadgetMap`/`gadgetsOn` destructured props. Verified the call site in `components/Visualization/svgs/Visualizations.js` still passes these via JSX (props matched by name), so this is a safe no-op — nothing breaks by no longer destructuring them.

No behavior changes — every removal was verified dead (either never read, or confirmed safe against its call site) before deleting.

## Test plan

- [x] `npx eslint <file>` on each touched file individually — clean (or only pre-existing, unrelated findings)
- [x] `npm run build` — production build compiles, all 7 routes prerender successfully

## Status

In all this fixes 31 unused variable warnings (about half)