### PR TITLE
Added Tag System Accessible through Tooltips, Filter Button, and Categories In Problems Dropdown On Website

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run build
         run: npm run build
+
+      - name: Check visualization type coverage
+        run: npm run check:visualizations

--- a/.github/workflows/manifest-drift.yml
+++ b/.github/workflows/manifest-drift.yml
@@ -1,0 +1,111 @@
+# Detects drift between the vendored visualization-type manifest and the API's
+# committed copy.
+#
+# The PR gate (main.yml -> npm run check:visualizations) proves the local registry
+# matches the local vendored manifest. It cannot notice that the vendored manifest
+# has itself gone stale, because a new API type ships in the other repo. That is the
+# gap this job closes.
+#
+# Deliberately NOT a PR gate: a network call to another repo inside the critical path
+# of every GUI pull request means unrelated PRs go red for reasons outside their diff.
+# This runs on a schedule instead and opens an issue, bounding staleness at ~24h
+# without ever blocking a contributor.
+name: manifest drift
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ReduxISU/Redux_GUI'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fetch the API's manifest
+        id: fetch
+        run: |
+          URL="https://raw.githubusercontent.com/ReduxISU/Redux/CSharpAPI/Documentation/visualization-types.json"
+          if ! curl -fsSL --retry 3 --retry-delay 5 -o api-manifest.json "$URL"; then
+            echo "Could not fetch $URL"
+            echo "fetch_failed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! jq empty api-manifest.json 2>/dev/null; then
+            echo "Fetched file is not valid JSON."
+            echo "fetch_failed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "fetch_failed=false" >> "$GITHUB_OUTPUT"
+
+      # A fetch failure is infrastructure noise (branch renamed, file moved, GitHub
+      # hiccup), not drift. Warn but never open an issue for it -- a job that cries
+      # wolf gets muted, and then real drift goes unnoticed too.
+      - name: Warn on fetch failure
+        if: steps.fetch.outputs.fetch_failed == 'true'
+        run: |
+          echo "::warning::Could not retrieve the API manifest; skipping drift comparison."
+
+      - name: Compare against the vendored copy
+        id: diff
+        if: steps.fetch.outputs.fetch_failed == 'false'
+        run: |
+          VENDORED="components/Visualization/svgs/visualizationTypes.json"
+          # Compare as sorted sets so formatting/key-order changes are not drift.
+          jq -S 'sort' api-manifest.json > /tmp/api.norm.json
+          jq -S 'sort' "$VENDORED"      > /tmp/vendored.norm.json
+
+          if diff -q /tmp/api.norm.json /tmp/vendored.norm.json >/dev/null; then
+            echo "In sync."
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "drifted=true" >> "$GITHUB_OUTPUT"
+          {
+            echo 'The API repo declares a different set of visualization types than this repo has vendored.'
+            echo
+            echo 'Only in the API (needs a renderer here, or an explicit alias):'
+            jq -r -n --slurpfile a /tmp/api.norm.json --slurpfile v /tmp/vendored.norm.json \
+              '($a[0] - $v[0])[] | "  - " + .'
+            echo
+            echo 'Only in this repo (stale entry, or a type the API removed):'
+            jq -r -n --slurpfile a /tmp/api.norm.json --slurpfile v /tmp/vendored.norm.json \
+              '($v[0] - $a[0])[] | "  - " + .'
+            echo
+            echo 'To resolve: copy the API manifest into'
+            echo "  $VENDORED"
+            echo 'and add a matching renderer key in components/Visualization/svgs/Visualizations.js'
+            echo 'for every new type except Unimplemented. Then `npm run check:visualizations`.'
+          } > drift-report.txt
+
+          cat drift-report.txt
+
+      - name: Open or update the drift issue
+        if: steps.diff.outputs.drifted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Visualization type manifest has drifted from the API"
+          BODY="$(cat drift-report.txt)
+
+          _Opened automatically by \`.github/workflows/manifest-drift.yml\`._"
+
+          # Reuse the open issue if one exists, so a persistent drift does not
+          # produce a new issue every single day.
+          EXISTING="$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)"
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi

--- a/Tools/check-visualization-coverage.mjs
+++ b/Tools/check-visualization-coverage.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// Cross-repo CI guard (Redux_GUI half). The API commits
+// Documentation/visualization-types.json as the source of truth for
+// `visualizationType`; this repo vendors a copy of it at
+// components/Visualization/svgs/visualizationTypes.json and this script
+// checks that copy against the renderer registry in Visualizations.js.
+//
+// Deliberately plain Node with zero dependencies: the only reason a test
+// runner would be needed is that Visualizations.js contains JSX, which
+// plain Node can't import -- so this reads the file as text and extracts
+// the registry keys with a regex instead of importing the module. That
+// makes the extraction fragile to certain refactors, which is what the two
+// structural guards below are for: they turn a silent zero-keys match into
+// a loud CI failure instead of a script that "passes" having checked
+// nothing.
+//
+// Run via `npm run check:visualizations`.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const VISUALIZATIONS_PATH = path.join(ROOT, "components/Visualization/svgs/Visualizations.js");
+const MANIFEST_PATH = path.join(ROOT, "components/Visualization/svgs/visualizationTypes.json");
+
+// Legacy (pre-rename) wire values kept in the registry for the dual-accept deploy window -- see
+// the header comment in Visualizations.js and plan section 2.10. Expected to NOT appear in the
+// vendored manifest; treated as an explicitly accepted set rather than as unknown/stale keys.
+// Once the aliases are deleted from Visualizations.js (2.10), delete this set too.
+const LEGACY_ALIASES = new Set([
+  "Graph D3",
+  "Graph LaTeX",
+  "Set D3",
+  "Boolean Satisfiability",
+  "Quantum Circuit D3",
+  "Quantum Circuit Q.js",
+  "pump",
+  "Dynamic Table",
+]);
+
+// Registered renderers with no current backend VisualizationType at all -- not a rename like
+// LEGACY_ALIASES above (there is no "DFATable"/"NFATable" manifest entry, old or new style). No
+// DFA/NFA problem's visualizationType is wired to emit these keys yet; kept registered because
+// the renderer components (DFATableSvgReact/NFATableSvgReact) already exist. Move an entry to
+// LEGACY_ALIASES instead if the API ever adds then renames a matching VisualizationType, or
+// remove it here once a real manifest entry supersedes it.
+const NOT_YET_BACKEND_WIRED = new Set(["DFA Table", "NFA Table"]);
+
+// Structural guard: below this many extracted keys, assume the regex broke rather than that the
+// registry actually shrank this much. Current registry has 8 current-name keys + 8 legacy
+// aliases + 2 not-yet-backend-wired keys = 18; set well below that but above zero so a broken
+// extractor can't sneak by.
+const MIN_EXTRACTED_KEYS = 9;
+
+const errors = [];
+function fail(message) {
+  errors.push(message);
+}
+
+function relPath(p) {
+  return path.relative(ROOT, p).split(path.sep).join("/");
+}
+
+function reportAndExit() {
+  if (errors.length > 0) {
+    console.error("check-visualization-coverage: FAILED\n");
+    for (const message of errors) {
+      console.error(`  - ${message}`);
+    }
+    process.exit(1);
+  }
+}
+
+const source = fs.readFileSync(VISUALIZATIONS_PATH, "utf8");
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+
+// --- Structural guard 1: exactly one `new Map(` ----------------------------
+// The extractor below assumes the registry is a single Map literal. If a refactor splits it,
+// renames it, or introduces a second Map in this file, the regex extraction below is no longer
+// trustworthy -- fail loudly instead of silently extracting the wrong set of keys.
+const mapCount = (source.match(/new Map\(/g) ?? []).length;
+if (mapCount !== 1) {
+  fail(
+    `expected exactly one "new Map(" in ${relPath(VISUALIZATIONS_PATH)}, found ${mapCount}. ` +
+      "This checker assumes a single registry Map; update the checker's extraction logic if " +
+      "that assumption changed on purpose.",
+  );
+}
+reportAndExit();
+
+// --- Extract registry keys --------------------------------------------------
+// Keys must be double-quoted string literals at the head of each Map entry -- see the header
+// comment in Visualizations.js. This intentionally does not parse JS; it only recognizes that
+// exact shape.
+//
+// Two narrowing steps before matching, both guarding against phantom keys -- a match found
+// somewhere that is not an actual registry entry. That failure mode is nastier than a missed
+// key, because it makes the checker report a renderer that does not exist:
+//   1. Start at the Map literal, so nothing in the file header can match. The header documents
+//      the required key shape, so it is exactly where someone would write a worked example.
+//   2. Strip comments inside the Map body, so a commented-out or illustrative entry is not
+//      counted as live.
+const mapStart = source.indexOf("new Map(");
+const registrySource = source
+  .slice(mapStart)
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+const keyPattern = /\[\s*"((?:[^"\\]|\\.)*)"\s*,/g;
+const registryKeys = [...registrySource.matchAll(keyPattern)].map((m) => m[1]);
+
+// --- Structural guard 2: enough keys extracted ------------------------------
+if (registryKeys.length < MIN_EXTRACTED_KEYS) {
+  fail(
+    `only extracted ${registryKeys.length} registry key(s) from ${relPath(VISUALIZATIONS_PATH)}, ` +
+      `expected at least ${MIN_EXTRACTED_KEYS}. Either the registry actually lost entries, or a ` +
+      "refactor (multi-line keys, single quotes, computed/templated keys, ...) broke this " +
+      "script's regex extraction -- fix Tools/check-visualization-coverage.mjs, don't ignore " +
+      "this failure.",
+  );
+}
+reportAndExit();
+
+const registryKeySet = new Set(registryKeys);
+const manifestSet = new Set(manifest);
+
+// (a) every manifest type except "Unimplemented" has a registry key.
+const missingFromRegistry = manifest.filter(
+  (type) => type !== "Unimplemented" && !registryKeySet.has(type),
+);
+if (missingFromRegistry.length > 0) {
+  fail(
+    "the vendored manifest declares visualizationType(s) with no renderer in " +
+      `${relPath(VISUALIZATIONS_PATH)}: ${missingFromRegistry.join(", ")}. Add a registry entry ` +
+      "for each, or if a type is genuinely not renderable it belongs represented as " +
+      '"Unimplemented" on the API side, not as its own manifest entry.',
+  );
+}
+
+// (b) every non-alias, non-not-yet-wired registry key is in the manifest.
+const unknownKeys = registryKeys.filter(
+  (key) => !manifestSet.has(key) && !LEGACY_ALIASES.has(key) && !NOT_YET_BACKEND_WIRED.has(key),
+);
+if (unknownKeys.length > 0) {
+  fail(
+    `${relPath(VISUALIZATIONS_PATH)} registers key(s) that are neither in the vendored manifest, ` +
+      "a recognized legacy alias, nor a recognized not-yet-backend-wired key: " +
+      `${unknownKeys.join(", ")}. This usually means a typo, a dead renderer that should be ` +
+      "removed, or a manifest that has drifted from the API " +
+      `(re-vendor ${relPath(MANIFEST_PATH)} from Redux's Documentation/visualization-types.json).`,
+  );
+}
+
+reportAndExit();
+
+console.log(
+  "check-visualization-coverage: OK " +
+    `(${registryKeys.length} registry keys, ${manifest.length} manifest types, ` +
+    `${LEGACY_ALIASES.size} legacy aliases, ${NOT_YET_BACKEND_WIRED.size} not-yet-backend-wired accepted)`,
+);

--- a/components/Visualization/svgs/No_Viz_SVG.js
+++ b/components/Visualization/svgs/No_Viz_SVG.js
@@ -69,3 +69,78 @@ export function No_Reduction_Viz_Svg({ niceReductionName }) {
         </Box>
     )
 }
+
+/**
+ * Shown when a declared `visualizationType` has no renderer registered for it (the "no
+ * renderer" case, distinct from a renderer that crashed -- see Viz_Render_Error_Svg). Names the
+ * TYPE, not the problem or reduction, since that's the actual missing piece; `niceProblemName`
+ * / `niceReductionName` are shown as extra context when available.
+ */
+export function No_Renderable_Viz_Svg({ niceProblemName, niceReductionName, visualizationType }) {
+    const contextName = niceReductionName ?? niceProblemName;
+    return (
+        <Box>
+            <Card variant="outlined"
+                sx={{
+                    bgcolor: 'primary.lGray',
+                    boxShadow: 1,
+                    borderRadius: 2,
+                    p: 2,
+                    minWidth: 300
+                }}
+            >
+                <ErrorOutlineIcon fontSize="large"></ErrorOutlineIcon>
+                <Typography
+                    variant="h4"
+                    component="h4"
+                    style={{
+                        color: 'black',
+                        fontWeight: 'normal',
+                        textAlign: 'center'
+                    }}
+                >
+                    {contextName ? `${contextName} declares` : "This visualization declares"} type
+                    &quot;{visualizationType || "unknown"}&quot;, which this interface can&apos;t render.
+                </Typography>
+            </Card>
+        </Box>
+    )
+}
+
+/**
+ * Shown when a visualization DOES have a registered renderer, but that renderer threw while
+ * rendering -- the "renderer crashed" case, distinct from "no renderer" (No_Renderable_Viz_Svg).
+ * Previously both cases were reported identically as "not implemented yet", which hid real
+ * bugs behind a missing-feature message.
+ */
+export function Viz_Render_Error_Svg({ niceProblemName, niceReductionName, visualizationType }) {
+    const contextName = niceReductionName ?? niceProblemName;
+    return (
+        <Box>
+            <Card variant="outlined"
+                sx={{
+                    bgcolor: 'primary.lGray',
+                    boxShadow: 1,
+                    borderRadius: 2,
+                    p: 2,
+                    minWidth: 300
+                }}
+            >
+                <ErrorOutlineIcon fontSize="large"></ErrorOutlineIcon>
+                <Typography
+                    variant="h4"
+                    component="h4"
+                    style={{
+                        color: 'black',
+                        fontWeight: 'normal',
+                        textAlign: 'center'
+                    }}
+                >
+                    {contextName ? `The ${contextName}` : "This"} visualization
+                    (type &quot;{visualizationType || "unknown"}&quot;) failed to render. Check the console
+                    for details.
+                </Typography>
+            </Card>
+        </Box>
+    )
+}

--- a/components/Visualization/svgs/Visualizations.js
+++ b/components/Visualization/svgs/Visualizations.js
@@ -1,117 +1,150 @@
+import QuantumCircuitVis from "../QuantumCircuitVis";
+import DFATableVisualization from "./DFATableSvgReact";
+import DynamicTableSvgReact from "./DynamicTableSvgReact";
+import LaTeXGraphSvgReact from "./LaTeXGraphSvgReact";
+import NFATableVisualization from "./NFATableSvgReact";
+import PumpSchedulingSvgReact from "./PumpSchedulingSvgReact";
+import StandardCircuitSvgReact from "./StandardCircuitSvgReact";
 import StandardGraphSvgReact from "./StandardGraphSvgReact";
 import StandardSATSvgReact from "./StandardSATSvgReact";
-import StandardCircuitSvgReact from "./StandardCircuitSvgReact";
-import QuantumCircuitVis from "../QuantumCircuitVis";
-import LaTeXGraphSvgReact from "./LaTeXGraphSvgReact";
 import StandardSetSvgReact from "./StandardSetSvgReact";
-import PumpSchedulingSvgReact from "./PumpSchedulingSvgReact";
-import DFATableVisualization from "./DFATableSvgReact";
-import NFATableVisualization from "./NFATableSvgReact";
-import DynamicTableSvgReact from "./DynamicTableSvgReact";
 
+const renderBooleanSatisfiability = (solve, url, problemData, gadgetMap, gadgetsOn) => {
+  return (
+    <StandardSATSvgReact
+      problemData={problemData}
+      solve={solve}
+      url={url}
+      gadgetMap={gadgetMap}
+      gadgetsOn={gadgetsOn}
+    ></StandardSATSvgReact>
+  );
+};
+
+const renderSetD3 = (solve, url, problemData, gadgetMap, gadgetsOn) => {
+  return (
+    <StandardSetSvgReact
+      problemData={problemData}
+      solve={solve}
+      url={url}
+      gadgetMap={gadgetMap}
+      gadgetsOn={gadgetsOn}
+    ></StandardSetSvgReact>
+  );
+};
+
+const renderGraphD3 = (solve, url, problemData, gadgetMap, gadgetsOn) => {
+  return (
+    <StandardGraphSvgReact
+      problemData={problemData}
+      solve={solve}
+      url={url}
+      gadgetMap={gadgetMap}
+      gadgetsOn={gadgetsOn}
+    ></StandardGraphSvgReact>
+  );
+};
+
+const renderGraphLaTeX = (solve, url, problemData, gadgetMap, gadgetsOn) => {
+  return (
+    <LaTeXGraphSvgReact
+      problemData={problemData}
+      solve={solve}
+      url={url}
+      gadgetMap={gadgetMap}
+      gadgetsOn={gadgetsOn}
+    ></LaTeXGraphSvgReact>
+  );
+};
+
+const renderQuantumCircuitD3 = (solve, url, problemData, gadgetMap, gadgetsOn) => {
+  return (
+    <StandardCircuitSvgReact
+      problemData={problemData}
+      solve={solve}
+      url={url}
+      gadgetMap={gadgetMap}
+      gadgetsOn={gadgetsOn}
+    ></StandardCircuitSvgReact>
+  );
+};
+
+const renderQuantumCircuitQjs = (solve, url, problemData, gadgetMap, gadgetsOn) => {
+  return (
+    <QuantumCircuitVis
+      problemData={problemData}
+      solve={solve}
+      url={url}
+      gadgetMap={gadgetMap}
+      gadgetsOn={gadgetsOn}
+    />
+  );
+};
+
+const renderPumpSchedule = (solve, url, problemData) => {
+  return <PumpSchedulingSvgReact problemData={problemData} solve={solve} url={url} />;
+};
+
+const renderDynamicTable = (solve, url, problemData) => {
+  return <DynamicTableSvgReact problemData={problemData} solve={solve} url={url} />;
+};
+
+const renderDFATable = (solve, url, problemData) => {
+  return <DFATableVisualization problemData={problemData} solve={solve} url={url} />;
+};
+
+const renderNFATable = (solve, url, problemData) => {
+  return <NFATableVisualization problemData={problemData} solve={solve} url={url} />;
+};
+
+/**
+ * Registry of visualization renderers, keyed by `visualizationType`.
+ *
+ * Keys MUST remain double-quoted string literals in first position within each Map entry's
+ * array (opening bracket, then immediately a double-quoted key, then a comma, then the factory)
+ * -- Tools/check-visualization-coverage.mjs extracts them with a regex, not a JS parser, and CI
+ * fails loudly if it can no longer find enough of them.
+ *
+ * Dual-accept window: the API is mid-rename from space-separated wire values (e.g. "Graph D3")
+ * to clean identifiers (e.g. "GraphD3"). Both are registered here, pointing at the same
+ * renderer, so this GUI image works against either the old or the new API image. The legacy
+ * aliases are scheduled for deletion once the rename has been deployed for one full release --
+ * see the implementation plan, section 2.10. Do not register a new renderer under a
+ * legacy-style key.
+ *
+ * "DFA Table"/"NFA Table" are a separate case from the legacy aliases above: there is no
+ * current backend `VisualizationType` for either (old-style or renamed) -- no DFA/NFA problem's
+ * `visualizationType` is wired to emit these keys yet. Kept registered because the renderer
+ * components already exist; see NOT_YET_BACKEND_WIRED in Tools/check-visualization-coverage.mjs
+ * for the matching CI exemption.
+ *
+ * "Unimplemented" is a sentinel meaning "no renderer is claimed" and is deliberately NOT a
+ * registry key -- see isRenderable() in ./renderability.js.
+ */
 const Visualizations = new Map([
-    ["Boolean Satisfiability" , (solve, url, problemData, gadgetMap, gadgetsOn) => {
-        return(
-            <StandardSATSvgReact 
-                problemData={problemData}
-                solve={solve}
-                url={url}
-                gadgetMap={gadgetMap}
-                gadgetsOn={gadgetsOn}
-            ></StandardSATSvgReact>  
-        )
-    }],
-    ["Set D3" , (solve, url, problemData, gadgetMap, gadgetsOn) => {
-        return(
-            <StandardSetSvgReact
-                problemData={problemData}
-                solve={solve}
-                url={url}
-                gadgetMap={gadgetMap}
-                gadgetsOn={gadgetsOn}
-            ></StandardSetSvgReact>  
-        )
-    }],
-    ["Graph D3", (solve, url, problemData, gadgetMap, gadgetsOn)=>{
-        return(
-        <StandardGraphSvgReact 
-            problemData={problemData}
-            solve={solve}
-            url={url}
-            gadgetMap={gadgetMap}
-            gadgetsOn={gadgetsOn}
-        ></StandardGraphSvgReact>
-        )
-    }],
-    ["Graph LaTeX", (solve, url, problemData, gadgetMap, gadgetsOn)=>{
-        return(
-        <LaTeXGraphSvgReact 
-            problemData={problemData}
-            solve={solve}
-            url={url}
-            gadgetMap={gadgetMap}
-            gadgetsOn={gadgetsOn}
-        ></LaTeXGraphSvgReact>
-        )
-    }],
-    ["Quantum Circuit D3", (solve, url, problemData, gadgetMap, gadgetsOn)=>{
-        return(
-        <StandardCircuitSvgReact
-            problemData={problemData}
-            solve={solve}
-            url={url}
-            gadgetMap={gadgetMap}
-            gadgetsOn={gadgetsOn}
-        ></StandardCircuitSvgReact>
-        )
-    }],
-    ["Quantum Circuit Q.js", (solve, url, problemData, gadgetMap, gadgetsOn) => {
-        return (
-            <QuantumCircuitVis
-                problemData={problemData}
-                solve={solve}
-                url={url}
-                gadgetMap={gadgetMap}
-                gadgetsOn={gadgetsOn}
-            />
-        );
-    }],
-    ["pump", (solve, url, problemData) => {
-        return (
-            <PumpSchedulingSvgReact
-                problemData={problemData}
-                solve={solve}
-                url={url}
-            />
-        );
-    }],
-    ["Dynamic Table", (solve, url, problemData) => {
-        return (
-            <DynamicTableSvgReact
-                problemData={problemData}
-                solve={solve}
-                url={url}
-            />
-        );
-    }],
-    ["DFA Table", (solve, url, problemData) => {
-        return (
-            <DFATableVisualization
-                problemData={problemData}
-                solve={solve}
-                url={url}
-            />
-        );
-    }],
-    ["NFA Table", (solve, url, problemData) => {
-        return (
-            <NFATableVisualization
-                problemData={problemData}
-                solve={solve}
-                url={url}
-            />
-        );
-    }]
-])
+  // -- current wire values --
+  ["BooleanSatisfiability", renderBooleanSatisfiability],
+  ["SetD3", renderSetD3],
+  ["GraphD3", renderGraphD3],
+  ["GraphLaTeX", renderGraphLaTeX],
+  ["QuantumCircuitD3", renderQuantumCircuitD3],
+  ["QuantumCircuitQjs", renderQuantumCircuitQjs],
+  ["PumpSchedule", renderPumpSchedule],
+  ["DynamicTable", renderDynamicTable],
+
+  // -- legacy aliases (dual-accept window; scheduled for deletion, see plan 2.10) --
+  ["Boolean Satisfiability", renderBooleanSatisfiability],
+  ["Set D3", renderSetD3],
+  ["Graph D3", renderGraphD3],
+  ["Graph LaTeX", renderGraphLaTeX],
+  ["Quantum Circuit D3", renderQuantumCircuitD3],
+  ["Quantum Circuit Q.js", renderQuantumCircuitQjs],
+  ["pump", renderPumpSchedule],
+  ["Dynamic Table", renderDynamicTable],
+
+  // -- not yet backend-wired (no matching VisualizationType exists yet) --
+  ["DFA Table", renderDFATable],
+  ["NFA Table", renderNFATable],
+]);
 
 export default Visualizations;

--- a/components/Visualization/svgs/renderability.js
+++ b/components/Visualization/svgs/renderability.js
@@ -1,0 +1,15 @@
+import Visualizations from "./Visualizations";
+
+/**
+ * Single chokepoint for "can this GUI actually draw this visualization type".
+ * Used by the picker (to disable unrenderable options), the auto-selection
+ * hook (to never auto-select an unrenderable option), and VisualizationLogic
+ * (to distinguish "no renderer" from "renderer crashed").
+ *
+ * `type` is a `visualizationType` wire value (e.g. "GraphD3"), not a
+ * visualization class name. "Unimplemented" is explicitly excluded: it is a
+ * declared sentinel meaning "no renderer is claimed", never a registry key.
+ */
+export function isRenderable(type) {
+  return Boolean(type) && type !== "Unimplemented" && Visualizations.has(type);
+}

--- a/components/Visualization/svgs/visualizationTypes.json
+++ b/components/Visualization/svgs/visualizationTypes.json
@@ -1,0 +1,11 @@
+[
+  "BooleanSatisfiability",
+  "DynamicTable",
+  "GraphD3",
+  "GraphLaTeX",
+  "PumpSchedule",
+  "QuantumCircuitD3",
+  "QuantumCircuitQjs",
+  "SetD3",
+  "Unimplemented"
+]

--- a/components/hooks/ProblemFilters/facetOptions.js
+++ b/components/hooks/ProblemFilters/facetOptions.js
@@ -1,0 +1,15 @@
+// Builds `[{key, label, count}]` for a facet: how many problems have each
+// distinct value, derived from the actual data rather than a hardcoded enum
+// list, so newly-declared tag values show up automatically.
+export function buildFacetOptions(problemIndex, pickValues) {
+  const counts = new Map();
+  for (const tags of problemIndex.values()) {
+    const values = pickValues(tags);
+    for (const value of values) {
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, count]) => ({ key, label: key, count }));
+}

--- a/components/hooks/ProblemFilters/useProblemFilters.js
+++ b/components/hooks/ProblemFilters/useProblemFilters.js
@@ -1,0 +1,135 @@
+import { useMemo, useState } from "react";
+
+/**
+ * `oneHop`: problems directly reachable from `source` via a single reduction
+ * edge -- `Object.keys(graph[source] ?? {})`.
+ */
+function reachableOneHop(graph, source) {
+  if (!source) return null;
+  return new Set(Object.keys(graph?.[source] ?? {}));
+}
+
+/**
+ * `anyHops`: every problem transitively reachable from `source` via any
+ * number of reduction edges, source excluded. Client-side mirror of the
+ * backend's `ReductionGraphData.ReachableFrom`
+ * (Redux/AdditionalControllers/Navigation/Nav_Reductions.cs) -- a plain BFS
+ * over the already-fetched graph object rather than a new endpoint.
+ */
+function reachableAnyHops(graph, source) {
+  if (!source) return null;
+  const visited = new Set([source]);
+  const queue = [source];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const next of Object.keys(graph?.[current] ?? {})) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  visited.delete(source);
+  return visited;
+}
+
+function intersects(setA, setB) {
+  for (const item of setA) {
+    if (setB.has(item)) return true;
+  }
+  return false;
+}
+
+/**
+ * Faceted filter state over the derived problem index from `useProblemIndex`,
+ * plus an optional reduction-reachability filter. Facets combine with AND;
+ * multiple selections within a single facet combine with OR (a problem
+ * matches a facet if its value/values intersect the selected set, or the
+ * set is empty meaning "no filter on that facet").
+ *
+ * @param problemIndex `Map<problemName, {complexityClass, solverTypes: Set,
+ * solverComplexityBuckets: Set, visualizationTypes: Set,
+ * hasRenderableVisualization}>` from `useProblemIndex`.
+ * @param reductionGraph Raw reduction graph object from `useProblemIndex`.
+ * @returns filter state, setters, the filtered problem-name list, and `clearFilters`.
+ */
+export function useProblemFilters(problemIndex, reductionGraph) {
+  const [selectedComplexityClasses, setSelectedComplexityClasses] = useState(new Set());
+  const [selectedSolverTypes, setSelectedSolverTypes] = useState(new Set());
+  const [selectedSolverComplexityBuckets, setSelectedSolverComplexityBuckets] = useState(new Set());
+  const [selectedVisualizationTypes, setSelectedVisualizationTypes] = useState(new Set());
+  const [reachabilitySource, setReachabilitySource] = useState(null);
+  const [reachabilityMode, setReachabilityMode] = useState("oneHop"); // "oneHop" | "anyHops"
+
+  const reachableSet = useMemo(() => {
+    if (!reachabilitySource) return null;
+    return reachabilityMode === "anyHops"
+      ? reachableAnyHops(reductionGraph, reachabilitySource)
+      : reachableOneHop(reductionGraph, reachabilitySource);
+  }, [reductionGraph, reachabilitySource, reachabilityMode]);
+
+  const filteredProblems = useMemo(() => {
+    const result = [];
+    for (const [problemName, tags] of problemIndex.entries()) {
+      if (
+        selectedComplexityClasses.size > 0 &&
+        !selectedComplexityClasses.has(tags.complexityClass)
+      ) {
+        continue;
+      }
+      if (selectedSolverTypes.size > 0 && !intersects(tags.solverTypes, selectedSolverTypes)) {
+        continue;
+      }
+      if (
+        selectedSolverComplexityBuckets.size > 0 &&
+        !intersects(tags.solverComplexityBuckets, selectedSolverComplexityBuckets)
+      ) {
+        continue;
+      }
+      if (
+        selectedVisualizationTypes.size > 0 &&
+        !intersects(tags.visualizationTypes, selectedVisualizationTypes)
+      ) {
+        continue;
+      }
+      if (reachableSet && !reachableSet.has(problemName)) {
+        continue;
+      }
+      result.push(problemName);
+    }
+    return result.sort((a, b) => a.localeCompare(b));
+  }, [
+    problemIndex,
+    selectedComplexityClasses,
+    selectedSolverTypes,
+    selectedSolverComplexityBuckets,
+    selectedVisualizationTypes,
+    reachableSet,
+  ]);
+
+  function clearFilters() {
+    setSelectedComplexityClasses(new Set());
+    setSelectedSolverTypes(new Set());
+    setSelectedSolverComplexityBuckets(new Set());
+    setSelectedVisualizationTypes(new Set());
+    setReachabilitySource(null);
+    setReachabilityMode("oneHop");
+  }
+
+  return {
+    selectedComplexityClasses,
+    setSelectedComplexityClasses,
+    selectedSolverTypes,
+    setSelectedSolverTypes,
+    selectedSolverComplexityBuckets,
+    setSelectedSolverComplexityBuckets,
+    selectedVisualizationTypes,
+    setSelectedVisualizationTypes,
+    reachabilitySource,
+    setReachabilitySource,
+    reachabilityMode,
+    setReachabilityMode,
+    filteredProblems,
+    clearFilters,
+  };
+}

--- a/components/hooks/ProblemFilters/useProblemIndex.js
+++ b/components/hooks/ProblemFilters/useProblemIndex.js
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import {
+  requestAllInfo,
+  requestAllProblems,
+  requestAllSolvers,
+  requestAllVisualizations,
+  requestAllVisualizationTypes,
+  requestReductionGraph,
+} from "../../redux";
+import { isRenderable } from "../../Visualization/svgs/renderability";
+
+/**
+ * Read-only, derived index over every problem's declared metadata tags --
+ * complexity class, the set of solver types it has solvers for, the set of
+ * solver complexity buckets (worst-case Big-O class: Polynomial/Exponential/
+ * Factorial) those solvers fall into, the set of visualization types it has
+ * visualizations for, and whether any of those visualizations are actually
+ * renderable by this GUI. Deliberately independent of `useProblemProvider`'s
+ * stateful selection-reducer tree: `/browse` needs a read-only index of ALL
+ * problems at once, not a single-selection flow.
+ *
+ * Also returns the raw reduction graph (from `requestReductionGraph`) for
+ * reachability filtering -- see `useProblemFilters`.
+ *
+ * @param url Base API URL, e.g. `/api/redux/`.
+ * @returns `{ problemIndex: Map<problemName, {complexityClass, solverTypes:
+ * Set<string>, solverComplexityBuckets: Set<string>, visualizationTypes:
+ * Set<string>, hasRenderableVisualization: boolean}>, reductionGraph: object,
+ * loading: boolean }`.
+ */
+export function useProblemIndex(url) {
+  const [problemIndex, setProblemIndex] = useState(new Map());
+  const [reductionGraph, setReductionGraph] = useState({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+
+      const [problems, allInfo, allSolvers, allVisualizations, allVisualizationTypes, graph] =
+        await Promise.all([
+          requestAllProblems(url),
+          requestAllInfo(url),
+          requestAllSolvers(url),
+          requestAllVisualizations(url),
+          requestAllVisualizationTypes(url),
+          requestReductionGraph(url),
+        ]);
+
+      if (cancelled) return;
+
+      const problemNames = problems ?? [];
+      const info = allInfo ?? {};
+      const solversByProblem = allSolvers ?? {};
+      const visualizationsByProblem = allVisualizations ?? {};
+      const visualizationTypes = allVisualizationTypes ?? null;
+
+      // Same fallback shape as useVisualizationTypeMap
+      // (components/hooks/ProblemProvider/Visualization.js): prefer the
+      // dedicated allVisualizationTypes endpoint, fall back to reading
+      // visualizationType off allInfo when that endpoint isn't deployed yet.
+      const resolveVisualizationType = (className) => {
+        if (visualizationTypes) {
+          return visualizationTypes[className];
+        }
+        return info[className]?.visualizationType || info[className]?.VisualizationType;
+      };
+
+      const map = new Map();
+      for (const problemName of problemNames) {
+        const problemInfo = info[problemName];
+        const complexityClass =
+          problemInfo?.complexityClass || problemInfo?.ComplexityClass || "Unclassified";
+
+        const solverTypes = new Set();
+        const solverComplexityBuckets = new Set();
+        for (const solverClassName of solversByProblem[problemName] ?? []) {
+          const solverInfo = info[solverClassName];
+          const solverType = solverInfo?.solverType || solverInfo?.SolverType || "Unclassified";
+          solverTypes.add(solverType);
+          const complexityBucket =
+            solverInfo?.complexityBucket || solverInfo?.ComplexityBucket || "Unclassified";
+          solverComplexityBuckets.add(complexityBucket);
+        }
+
+        const visualizationTypeSet = new Set();
+        let hasRenderableVisualization = false;
+        for (const visClassName of visualizationsByProblem[problemName] ?? []) {
+          const type = resolveVisualizationType(visClassName);
+          if (type) {
+            visualizationTypeSet.add(type);
+          }
+          if (isRenderable(type)) {
+            hasRenderableVisualization = true;
+          }
+        }
+
+        map.set(problemName, {
+          complexityClass,
+          solverTypes,
+          solverComplexityBuckets,
+          visualizationTypes: visualizationTypeSet,
+          hasRenderableVisualization,
+        });
+      }
+
+      setProblemIndex(map);
+      setReductionGraph(graph ?? {});
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return { problemIndex, reductionGraph, loading };
+}

--- a/components/hooks/ProblemProvider/Reducer.js
+++ b/components/hooks/ProblemProvider/Reducer.js
@@ -77,7 +77,7 @@ function useReductionVisualization(url, chosenReduceTo) {
 
     (async () => {
       const info = await requestInfo(url, chosenReduceTo);
-      setReductionVisualization(info?.defaultVisualization.visualizationType ?? "");
+      setReductionVisualization(info?.defaultVisualization?.visualizationType ?? "");
     })();
   }, [url, chosenReduceTo]);
 

--- a/components/hooks/ProblemProvider/Solver.js
+++ b/components/hooks/ProblemProvider/Solver.js
@@ -27,6 +27,22 @@ function useSolvedInstance(problemInstance, chosenSolver) {
   return [solvedInstance, setSolvedInstance];
 }
 
+// Builds the label shown for a solver in the dropdown. When the backend has
+// classified the solver (a non-empty, non-"Unclassified" solverType plus a
+// non-empty complexity), append that info; otherwise fall back to the plain
+// solver name so untagged solvers don't render an ugly "(Unclassified · )".
+function formatSolverLabel(info, fallback) {
+  const name = info?.solverName || fallback;
+  const solverType = info?.solverType;
+  const complexity = info?.complexity;
+
+  if (solverType && complexity && solverType !== "Unclassified") {
+    return `${name} (${solverType} · ${complexity})`;
+  }
+
+  return name;
+}
+
 function useSolverNameMap(url, problemNameMap) {
   const [solverNameMap, setSolverNameMap] = useState(new Map());
 
@@ -42,7 +58,7 @@ function useSolverNameMap(url, problemNameMap) {
         for (const s of solvers) {
           const solver = s.split(" ")[0];
           const info = allInfo[solver];
-          map.set(s, info?.solverName || s);
+          map.set(s, formatSolverLabel(info, s));
         }
       }
       setSolverNameMap(map);

--- a/components/hooks/ProblemProvider/Visualization.js
+++ b/components/hooks/ProblemProvider/Visualization.js
@@ -1,12 +1,23 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  requestAllInfo,
+  requestAllVisualizations,
+  requestAllVisualizationTypes,
+} from "../../redux";
+import { isRenderable } from "../../Visualization/svgs/renderability";
 import { useGenericInfo } from "../ProblemProvider";
-import { requestAllVisualizations, requestAllInfo } from "../../redux";
-import React, { useEffect, useState, useRef } from "react";
 
 export function useVisualization(url, problemName, problemNameMap, problemInfoMap) {
   const state = {};
   [state.defaultVisualizationMap] = useDefaultVisualizationMap(url, problemInfoMap);
   [state.VisualizationOptions] = useVisualizationOptions(url, problemName);
-  [state.chosenVisualization, state.setChosenVisualization] = useChosenVisualization(problemName, state.defaultVisualizationMap);
+  state.visualizationTypeMap = useVisualizationTypeMap(url, state.VisualizationOptions);
+  [state.chosenVisualization, state.setChosenVisualization] = useChosenVisualization(
+    problemName,
+    state.defaultVisualizationMap,
+    state.VisualizationOptions,
+    state.visualizationTypeMap,
+  );
   [state.VisualizationNameMap] = useVisualizationNameMap(url, problemNameMap);
   return state;
 }
@@ -24,7 +35,7 @@ function useDefaultVisualizationMap(url, problemInfoMap) {
       .map(
         (info) =>
           info?.defaultVisualization?.visualizationName ||
-          info?.defaultVisualization?.VisualizationName
+          info?.defaultVisualization?.VisualizationName,
       )
       .filter(Boolean);
     (async () => {
@@ -34,12 +45,11 @@ function useDefaultVisualizationMap(url, problemInfoMap) {
       let map = new Map();
       for (const problem of problems) {
         const visualizations = allVisualizations[problem] ?? [];
-        for (const v of visualizations) {
-          const visualization = v.split(" ")[0];
+        for (const visualization of visualizations) {
           const info = allInfo[visualization];
           const visName = info?.visualizationName || info?.VisualizationName;
           if (visName && defaultVisualizationNames.includes(visName)) {
-            map.set(problem, v);
+            map.set(problem, visualization);
           }
         }
       }
@@ -67,7 +77,60 @@ function useVisualizationOptions(url, problemName) {
   return [VisualizationOptions, setVisualizationOptions];
 }
 
-function useChosenVisualization(problemName, defaultVisualizationMap) {
+/**
+ * Bridges `VisualizationOptions` (visualization CLASS NAMES, e.g.
+ * "CliqueDefaultVisualization") to the renderer registry, which is keyed on
+ * `visualizationType` (e.g. "GraphD3") -- returns a `Map<className, type>`.
+ *
+ * Prefers the `Navigation/Batch/allVisualizationTypes` endpoint. That
+ * endpoint may not be deployed on the connected API yet, in which case
+ * `requestAllVisualizationTypes` resolves to `undefined` (fetchJson
+ * swallows the failure), and this falls back to reading `visualizationType`
+ * off each class's entry in `allInfo` instead. Both paths must work.
+ */
+function useVisualizationTypeMap(url, VisualizationOptions) {
+  const [visualizationTypeMap, setVisualizationTypeMap] = useState(new Map());
+
+  useEffect(() => {
+    (async () => {
+      if (!VisualizationOptions?.length) {
+        setVisualizationTypeMap(new Map());
+        return;
+      }
+
+      const allTypes = await requestAllVisualizationTypes(url);
+      const map = new Map();
+
+      if (allTypes) {
+        for (const className of VisualizationOptions) {
+          const type = allTypes[className];
+          if (type) map.set(className, type);
+        }
+      } else {
+        // allVisualizationTypes isn't deployed on the connected API yet --
+        // derive the same className -> type mapping from allInfo, which
+        // already carries visualizationType per visualization.
+        const allInfo = (await requestAllInfo(url)) ?? {};
+        for (const className of VisualizationOptions) {
+          const type =
+            allInfo[className]?.visualizationType || allInfo[className]?.VisualizationType;
+          if (type) map.set(className, type);
+        }
+      }
+
+      setVisualizationTypeMap(map);
+    })();
+  }, [url, VisualizationOptions]);
+
+  return visualizationTypeMap;
+}
+
+function useChosenVisualization(
+  problemName,
+  defaultVisualizationMap,
+  VisualizationOptions,
+  visualizationTypeMap,
+) {
   const [chosenVisualization, setChosenVisualization] = useState("");
   const [byProblem, setByProblem] = useState({}); // { [problemName]: vis }
   const userSelected = useRef(false);
@@ -82,27 +145,44 @@ function useChosenVisualization(problemName, defaultVisualizationMap) {
   useEffect(() => {
     if (!problemName) return;
 
-    // On problem change: load stored or default
     if (problemName !== lastProblem.current) {
       lastProblem.current = problemName;
       userSelected.current = false;
-      const stored = byProblem[problemName];
-      const def = defaultVisualizationMap.get(problemName) || "";
-      const next = stored ?? def;
-      setChosenVisualization(next);
-      return;
     }
 
-    // After defaults load for the same problem: only if nothing chosen/stored
-    if (!userSelected.current && !byProblem[problemName] && !chosenVisualization) {
-      const def = defaultVisualizationMap.get(problemName) || "";
-      setChosenVisualization(def);
+    // An explicit user choice (this session) always wins; never overwrite it
+    // with a re-resolved default.
+    if (userSelected.current) return;
+
+    const isOptionRenderable = (option) => isRenderable(visualizationTypeMap.get(option));
+
+    // Resolution order:
+    //   1. stored per-problem user choice (survives switching problems and back)
+    //   2. backend-declared default from defaultVisualizationMap, iff it is renderable
+    //   3. first renderable option
+    //   4. "" -- explicit empty state; nothing renderable for this problem
+    const stored = byProblem[problemName];
+    const backendDefault = defaultVisualizationMap.get(problemName);
+    const next =
+      stored ??
+      (backendDefault && isOptionRenderable(backendDefault) ? backendDefault : undefined) ??
+      (VisualizationOptions ?? []).find(isOptionRenderable) ??
+      "";
+
+    if (next !== chosenVisualization) {
+      setChosenVisualization(next);
     }
-  }, [problemName, defaultVisualizationMap, chosenVisualization, byProblem]);
+  }, [
+    problemName,
+    defaultVisualizationMap,
+    VisualizationOptions,
+    visualizationTypeMap,
+    byProblem,
+    chosenVisualization,
+  ]);
 
   return [chosenVisualization, setChosenVisualizationSafe];
 }
-
 
 function useVisualizationNameMap(url, problemNameMap) {
   const [VisualizationNameMap, setVisualizationNameMap] = useState(new Map());
@@ -121,7 +201,7 @@ function useVisualizationNameMap(url, problemNameMap) {
           const info = allInfo[visualization];
           map.set(
             visualization,
-            info?.visualizationName || info?.VisualizationName || visualization
+            info?.visualizationName || info?.VisualizationName || visualization,
           );
         }
       }

--- a/components/hooks/ProblemProvider/Visualization.js
+++ b/components/hooks/ProblemProvider/Visualization.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   requestAllInfo,
   requestAllVisualizations,
@@ -131,55 +131,37 @@ function useChosenVisualization(
   VisualizationOptions,
   visualizationTypeMap,
 ) {
-  const [chosenVisualization, setChosenVisualization] = useState("");
   const [byProblem, setByProblem] = useState({}); // { [problemName]: vis }
-  const userSelected = useRef(false);
-  const lastProblem = useRef(null);
 
   const setChosenVisualizationSafe = (value) => {
-    userSelected.current = true;
     setByProblem((prev) => ({ ...prev, [problemName]: value }));
-    setChosenVisualization(value);
   };
 
-  useEffect(() => {
-    if (!problemName) return;
-
-    if (problemName !== lastProblem.current) {
-      lastProblem.current = problemName;
-      userSelected.current = false;
-    }
-
-    // An explicit user choice (this session) always wins; never overwrite it
-    // with a re-resolved default.
-    if (userSelected.current) return;
-
+  // Derived, not stored: chosenVisualization is a pure function of the arguments above, so
+  // it's computed directly during render instead of via an Effect + setState (the latter
+  // triggers an extra "cascading render" -- see
+  // https://react.dev/learn/you-might-not-need-an-effect). byProblem already reflects a
+  // just-made user choice by the very next render (setByProblem and this computation now
+  // run in the same pass), so no separate "user selected" guard is needed: an explicit
+  // choice already wins via the `stored` branch below, with no effect-lag window where it
+  // could be raced by a re-resolved default.
+  //
+  // Resolution order:
+  //   1. stored per-problem user choice (survives switching problems and back)
+  //   2. backend-declared default from defaultVisualizationMap, iff it is renderable
+  //   3. first renderable option
+  //   4. "" -- explicit empty state; nothing renderable for this problem
+  let chosenVisualization = "";
+  if (problemName) {
     const isOptionRenderable = (option) => isRenderable(visualizationTypeMap.get(option));
-
-    // Resolution order:
-    //   1. stored per-problem user choice (survives switching problems and back)
-    //   2. backend-declared default from defaultVisualizationMap, iff it is renderable
-    //   3. first renderable option
-    //   4. "" -- explicit empty state; nothing renderable for this problem
     const stored = byProblem[problemName];
     const backendDefault = defaultVisualizationMap.get(problemName);
-    const next =
+    chosenVisualization =
       stored ??
       (backendDefault && isOptionRenderable(backendDefault) ? backendDefault : undefined) ??
       (VisualizationOptions ?? []).find(isOptionRenderable) ??
       "";
-
-    if (next !== chosenVisualization) {
-      setChosenVisualization(next);
-    }
-  }, [
-    problemName,
-    defaultVisualizationMap,
-    VisualizationOptions,
-    visualizationTypeMap,
-    byProblem,
-    chosenVisualization,
-  ]);
+  }
 
   return [chosenVisualization, setChosenVisualizationSafe];
 }

--- a/components/pageblocks/ProblemRowReact.js
+++ b/components/pageblocks/ProblemRowReact.js
@@ -17,7 +17,10 @@ import { Folder as FolderIcon } from '@mui/icons-material';
 import { Download as DownloadIcon } from '@mui/icons-material';
 
 import PopoverTooltipClick from '../widgets/PopoverTooltipClick';
+import ProblemFilterMenu from '../widgets/ProblemFilterMenu';
 import { useProblemInfo } from '../hooks/ProblemProvider'
+import { useProblemIndex } from '../hooks/ProblemFilters/useProblemIndex';
+import { useProblemFilters } from '../hooks/ProblemFilters/useProblemFilters';
 import ProblemInstanceParser from '../../Tools/ProblemInstanceParser';
 import ProblemSection from '../widgets/ProblemSection';
 import SearchBarExtensible from '../widgets/SearchBarExtensible';
@@ -28,11 +31,28 @@ var CARD = { cardBodyText: "Instance", cardHeaderText: "Problem", problemInstanc
 const TOOLTIP = { header: "Problem Information", formalDef: "Choose a problem to see information about it", info: "", credit: "" }
 const THEME = { colors: { grey: "#424242", orange: "#d4441c" } };
 
+// Display order for the dropdown's complexity-class sections. Unclassified
+// last -- it's the "not yet tagged" bucket, not a real complexity class.
+const COMPLEXITY_CLASS_ORDER = ["P", "NPComplete", "NPHard", "NPIntermediate", "QuantumOracle", "Unclassified"];
+
 /**
  *  Creates an accordion that has a nested autocomplete search bar, as well as an editable problem instance textbox
  */
 export default function ProblemRowReact({ url, problemName, setProblemName, problemNameMap, setProblemInstance }) {
   const problemInfo = useProblemInfo(url, problemName);
+  const { problemIndex, reductionGraph } = useProblemIndex(url);
+  const {
+    selectedComplexityClasses,
+    setSelectedComplexityClasses,
+    selectedSolverComplexityBuckets,
+    setSelectedSolverComplexityBuckets,
+    filteredProblems,
+    clearFilters,
+  } = useProblemFilters(problemIndex, reductionGraph);
+  // problemIndex is fetched independently of problemNameMap (a separate hook
+  // chain); intersect so a momentary population lag between the two can't put
+  // an unlabeled option in the dropdown.
+  const filteredProblemOptions = filteredProblems.filter((name) => problemNameMap.has(name));
   const [problemLocalInstance, setProblemLocalInstance] = useState("")
   const defaultInstanceParsed = {
     test: true,
@@ -148,8 +168,11 @@ export default function ProblemRowReact({ url, problemName, setProblemName, prob
       ? {
           header: problemInfo.problemName ?? "",
           formalDef: problemInfo.formalDefinition ?? "",
-          // It makes description clean 
+          // It makes description clean
           info: problemInfo.problemDefinition ?? "",
+          classification: [
+            { label: "Complexity class", value: problemInfo.complexityClass || "Unclassified" },
+          ],
           // Source shown on its own line here
           source:
             problemInfo.source ||
@@ -174,14 +197,24 @@ export default function ProblemRowReact({ url, problemName, setProblemName, prob
           placeholder={ACCORDION_FORM_ONE.placeHolder}
           selected={problemName}
           onSelect={setProblemName}
-          options={[...problemNameMap.keys()]}
+          options={filteredProblemOptions}
           optionsMap={problemNameMap}
+          groupBy={(key) => problemIndex.get(key)?.complexityClass || "Unclassified"}
+          groupOrder={COMPLEXITY_CLASS_ORDER}
           extenderButtons={(input) => [
             {
               label: `Add new problem "${input}"`,
               href: `${url}ProblemTemplate/?problemName=${input}`,
             },
           ]}
+        />{" "}
+        <ProblemFilterMenu
+          problemIndex={problemIndex}
+          selectedComplexityClasses={selectedComplexityClasses}
+          setSelectedComplexityClasses={setSelectedComplexityClasses}
+          selectedSolverComplexityBuckets={selectedSolverComplexityBuckets}
+          setSelectedSolverComplexityBuckets={setSelectedSolverComplexityBuckets}
+          clearFilters={clearFilters}
         />{" "}
          <PopoverTooltipClick toolTip={tip} />
       </ProblemSection.Header>

--- a/components/pageblocks/ReduceToRowReact.js
+++ b/components/pageblocks/ReduceToRowReact.js
@@ -31,6 +31,17 @@ const TOOLTIP1 = { header: "Reduce To Problem", formalDef: "Choose a problem to 
 const TOOLTIP2 = { header: "Reduction Type", formalDef: "Choose a type of reduction to see information about it", info: "" }
 const THEME = { colors: { grey: "#424242", orange: "#d4441c", white: "#ffffff" } }
 
+// ReductionCost describes output-size blowup relative to input size -- the
+// closest thing reductions have to a Big-O figure (reductions themselves
+// don't have a runtime complexity class the way problems/solvers do).
+const REDUCTION_COST_LABELS = {
+  Linear: "Linear (O(n))",
+  Quadratic: "Quadratic (O(n²))",
+  Cubic: "Cubic (O(n³))",
+  HigherPolynomial: "Higher polynomial (O(n^k), k > 3)",
+  Unclassified: "Unclassified",
+}
+
 export default function ReduceToRowReact({
   url,
   problemName,
@@ -95,10 +106,13 @@ export default function ReduceToRowReact({
               ? {
                 header: reduceToInfo.problemName ?? "",
                 formalDef: reduceToInfo.formalDefinition ?? "",
-                // description only 
+                // description only
                 info: reduceToInfo.problemDefinition ?? "",
-                // show source 
-                source: reduceToInfo.source, 
+                classification: [
+                  { label: "Complexity class", value: reduceToInfo.complexityClass || "Unclassified" },
+                ],
+                // show source
+                source: reduceToInfo.source,
                 credit:
                   Array.isArray(reduceToInfo.contributors) &&
                     reduceToInfo.contributors.length
@@ -142,6 +156,12 @@ export default function ReduceToRowReact({
                 formalDef: reducerInfo.reductionDefinition ?? "",
                 // plain description for the reduction
                 info: reducerInfo.info ?? reducerInfo.description ?? "",
+                classification: [
+                  {
+                    label: "Reduction cost",
+                    value: REDUCTION_COST_LABELS[reducerInfo.cost] || reducerInfo.cost || "Unclassified",
+                  },
+                ],
                 // separate Source line
                 source: reducerInfo.source,
                 // contributors if present

--- a/components/pageblocks/SolveRowReact.js
+++ b/components/pageblocks/SolveRowReact.js
@@ -27,6 +27,9 @@ const TOOLTIP = {
   header: "Solver Information",
   formalDef: "Choose a type of solver to see information about it",
   info: "",
+  solverType: "",
+  complexity: "",
+  complexityBucket: "",
 };
 const THEME = { colors: { grey: "#424242", orange: "#d4441c" } };
 
@@ -73,7 +76,7 @@ export default function SolveRowReact({
         formalDef: solverInfo.solverDefinition ?? "",
         // Keep description clean
         info: solverInfo.info ?? solverInfo.description ?? "",
-        // Source on its own line 
+        // Source on its own line
         source: solverInfo.source,
         credit:
           Array.isArray(solverInfo.contributors) && solverInfo.contributors.length
@@ -82,6 +85,12 @@ export default function SolveRowReact({
 
         componentLink: solverInfo.solverLink || "",
         sourceLink: solverInfo.sourceLink || "",
+
+        classification: [
+          { label: "Solver type", value: solverInfo.solverType || "Unclassified" },
+          { label: "Complexity bucket", value: solverInfo.complexityBucket || "Unclassified" },
+          { label: "Big-O", value: solverInfo.complexity || "Not yet determined" },
+        ],
       }
       : TOOLTIP;
 

--- a/components/pageblocks/VisualizeRowReact.js
+++ b/components/pageblocks/VisualizeRowReact.js
@@ -38,6 +38,7 @@ import {
 import VisualizationLogic from "../widgets/VisualizationLogic";
 import ProblemSection from "../widgets/ProblemSection";
 import { useVisualizationInfo } from "../hooks/ProblemProvider";
+import { isRenderable } from "../Visualization/svgs/renderability";
 
 const CARD = { cardBodyText: "DEFAULT BODY", cardHeaderText: "Visualize" };
 const SWITCHES = {
@@ -69,8 +70,17 @@ export default function VisualizeRowReact({
   setChosenVisualization,
   VisualizationOptions,
   defaultVisualizationMap,
+  visualizationTypeMap,
 }) {
   const visualizationInfo = useVisualizationInfo(url, chosenVisualization);
+
+  const unrenderableOptions = (VisualizationOptions || []).filter(
+    (option) => !isRenderable(visualizationTypeMap?.get(option))
+  );
+  const hasRenderableOption = (VisualizationOptions || []).some(
+    (option) => !unrenderableOptions.includes(option)
+  );
+  const noRenderableOptions = (VisualizationOptions || []).length > 0 && !hasRenderableOption;
 
   const defaultSat3VisualizationArr = [
     ["x1", "!x2", "x3"],
@@ -128,12 +138,11 @@ export default function VisualizeRowReact({
     setCurrentStep(0);
   }, [problemName, problemInstance, chosenVisualization]);
 
-  // When the problem changes with no auto-selected visualization, fall back to the first available option
-  useEffect(() => {
-    if (!chosenVisualization && VisualizationOptions?.length > 0) {
-      setChosenVisualization(VisualizationOptions[0]);
-    }
-  }, [problemName, VisualizationOptions, chosenVisualization]);
+  // Visualization selection (stored choice / renderable default / first renderable option /
+  // explicit empty state) is fully resolved inside useChosenVisualization -- see
+  // components/hooks/ProblemProvider/Visualization.js. Do not add a fallback-pick effect here:
+  // calling setChosenVisualization from this component marks the pick as "user selected" and
+  // permanently blocks the hook's own default resolution for that problem.
 
   // fetch solution when instance or solver changes, since it's needed for some visualizations and reductions
   const [solution, setSolution] = useState(undefined);
@@ -331,6 +340,9 @@ export default function VisualizeRowReact({
       header: visualizationInfo.visualizationName ?? "",
       formalDef: visualizationInfo.visualizationDefinition ?? "",
       info: visualizationInfo.info ?? visualizationInfo.description ?? "",
+      classification: [
+        { label: "Visualization type", value: visualizationInfo.visualizationType || "Unclassified" },
+      ],
       source: visualizationInfo.source,
       credit:
         Array.isArray(visualizationInfo.contributors) &&
@@ -351,8 +363,14 @@ export default function VisualizeRowReact({
           onSelect={setChosenVisualization}
           options={VisualizationOptions || []}
           optionsMap={VisualizationNameMap}
-          disabled={!problemName}
-          disabledMessage="No visualization available. Please select a problem."
+          optionsDisabled={unrenderableOptions}
+          disabledOptionHint="no renderer available"
+          disabled={!problemName || noRenderableOptions}
+          disabledMessage={
+            noRenderableOptions
+              ? "No renderable visualization for this problem"
+              : "No visualization available. Please select a problem."
+          }
           extenderButtons={(input) => [
             {
               label: `Add new visualization "${input}"`,

--- a/components/redux/index.js
+++ b/components/redux/index.js
@@ -497,3 +497,34 @@ export function requestAllInfo(url) {
       )
   );
 }
+
+/**
+ * @returns an object mapping each visualization class name (e.g. "CliqueDefaultVisualization")
+ * to its `visualizationType` wire value (e.g. "GraphD3").
+ * @returns cached data when available to reduce API calls.
+ * @returns `undefined` on failure and logs the error, including when the endpoint doesn't exist
+ * yet on the connected API -- callers should fall back to deriving this mapping from
+ * `requestAllInfo` in that case.
+ */
+export function requestAllVisualizationTypes(url) {
+  return cachedRequest(
+    `${url}|allVisualizationTypes`,
+    () =>
+      fetchJson(
+        `${url}Navigation/Batch/allVisualizationTypes`,
+        () => "ALL VISUALIZATION TYPES REQUEST FAILED"
+      )
+  );
+}
+
+/**
+ * @returns the full reduction graph as an adjacency map:
+ * `{ [fromProblemName]: { [toProblemName]: [{className, endpoint, inputType, outputType,
+ * fromComplexity, toComplexity, cost}] } }`.
+ * @returns cached data when available to reduce API calls.
+ * @returns `undefined` on failure and logs the error.
+ */
+export function requestReductionGraph(url) {
+  return cachedRequest(`${url}|reductionGraph`, () =>
+    fetchJson(`${url}Navigation/Reductions`, () => "REDUCTION GRAPH REQUEST FAILED"));
+}

--- a/components/widgets/FacetFilterGroup.js
+++ b/components/widgets/FacetFilterGroup.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { Checkbox, FormControlLabel, FormGroup, Typography, Box } from "@mui/material";
+
+/**
+ * Generic, reusable multi-select checkbox facet. Not specific to any one
+ * facet's meaning (complexity class, solver type, visualization type, ...) --
+ * pass the option list and it just renders checkboxes and toggles set
+ * membership.
+ *
+ * @param label Facet group heading.
+ * @param options `[{key, label, count}]`, the distinct values actually
+ * present in the data (not a hardcoded enum list).
+ * @param selected `Set` of currently-selected option keys.
+ * @param onChange Called with the next `Set` whenever a checkbox is toggled.
+ */
+export default function FacetFilterGroup({ label, options, selected, onChange }) {
+  const toggle = (key) => {
+    const next = new Set(selected);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    onChange(next);
+  };
+
+  return (
+    <Box>
+      <Typography
+        sx={{
+          color: "#ffffff",
+          fontSize: "0.78rem",
+          fontWeight: 600,
+          letterSpacing: "0.14em",
+          mb: 0.5,
+        }}
+      >
+        {label.toUpperCase()}
+      </Typography>
+      <FormGroup>
+        {options.length === 0 ? (
+          <Typography sx={{ color: "#6b7280", fontSize: "0.8rem", fontStyle: "italic" }}>
+            No values available
+          </Typography>
+        ) : (
+          options.map(({ key, label: optionLabel, count }) => (
+            <FormControlLabel
+              key={key}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={selected.has(key)}
+                  onChange={() => toggle(key)}
+                  sx={{
+                    color: "rgba(255,255,255,0.35)",
+                    "&.Mui-checked": { color: "#a855f7" },
+                  }}
+                />
+              }
+              label={
+                <Typography sx={{ color: "#d1d5db", fontSize: "0.83rem" }}>
+                  {optionLabel} <Box component="span" sx={{ color: "#6b7280" }}>({count})</Box>
+                </Typography>
+              }
+            />
+          ))
+        )}
+      </FormGroup>
+    </Box>
+  );
+}

--- a/components/widgets/PopoverTooltipClick.js
+++ b/components/widgets/PopoverTooltipClick.js
@@ -28,7 +28,7 @@ function PopoverTooltipClick({ toolTip = {} }) {
       <InfoOutlinedIcon
         onClick={handleClick}
         style={{ cursor: 'pointer' }}
-        fontSize="small"
+        fontSize="medium"
       />
 
       <Popover
@@ -86,6 +86,23 @@ function PopoverTooltipClick({ toolTip = {} }) {
                   </Link>
                 )}
               </Typography>
+            ) : null}
+
+            {Array.isArray(t.classification) && t.classification.length > 0 ? (
+              <Box
+                sx={{
+                  mb: 1.5,
+                  p: '6px 10px',
+                  borderRadius: 1,
+                  bgcolor: 'rgba(0,0,0,0.04)',
+                }}
+              >
+                {t.classification.map(({ label, value }) => (
+                  <Typography key={label} variant="body2" sx={{ lineHeight: 1.35 }}>
+                    <strong>{label}:</strong> {value}
+                  </Typography>
+                ))}
+              </Box>
             ) : null}
 
             {t.source ? (

--- a/components/widgets/ProblemCard.js
+++ b/components/widgets/ProblemCard.js
@@ -1,0 +1,88 @@
+import React from "react";
+import Link from "next/link";
+import { Box, Chip, Typography } from "@mui/material";
+import { CheckCircle as CheckCircleIcon, RemoveCircleOutlined as DashIcon } from "@mui/icons-material";
+
+// Same glassmorphism card treatment as pages/aboutus/index.js's theSectionCard,
+// scaled down for a dense grid of many cards.
+const cardSx = {
+  background: "rgba(255,255,255,0.05)",
+  backdropFilter: "blur(10px)",
+  borderRadius: "16px",
+  border: "1px solid rgba(255,255,255,0.10)",
+  padding: 2,
+  height: "100%",
+  transition: "all 0.3s ease",
+  "&:hover": {
+    borderColor: "rgba(168,85,247,0.4)",
+    boxShadow: "0 0 25px rgba(168,85,247,0.15)",
+  },
+};
+
+/**
+ * Presentational card for one problem in the /browse results grid. Clicking
+ * the problem name navigates to `/?problem=<name>`, which the home page
+ * reads on mount to auto-select that problem.
+ */
+export default function ProblemCard({ name, complexityClass, solverTypes, hasRenderableVisualization }) {
+  return (
+    <Box sx={cardSx}>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 1 }}>
+        <Link
+          href={`/?problem=${encodeURIComponent(name)}`}
+          style={{ textDecoration: "none" }}
+        >
+          <Typography
+            sx={{
+              color: "#ffffff",
+              fontWeight: 600,
+              fontSize: "1rem",
+              "&:hover": { color: "#d8b4fe" },
+            }}
+          >
+            {name}
+          </Typography>
+        </Link>
+        {hasRenderableVisualization ? (
+          <CheckCircleIcon titleAccess="Has a renderable visualization" sx={{ color: "#4ade80", fontSize: "1.1rem" }} />
+        ) : (
+          <DashIcon titleAccess="No renderable visualization" sx={{ color: "#4b5563", fontSize: "1.1rem" }} />
+        )}
+      </Box>
+
+      <Chip
+        label={complexityClass}
+        size="small"
+        sx={{
+          mb: 1.25,
+          color: "#e9d5ff",
+          background: "rgba(168,85,247,0.15)",
+          border: "1px solid rgba(168,85,247,0.35)",
+          fontSize: "0.72rem",
+        }}
+      />
+
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+        {solverTypes.length === 0 ? (
+          <Typography sx={{ color: "#6b7280", fontSize: "0.75rem", fontStyle: "italic" }}>
+            No solvers
+          </Typography>
+        ) : (
+          solverTypes.map((type) => (
+            <Chip
+              key={type}
+              label={type}
+              size="small"
+              sx={{
+                color: "#d1d5db",
+                background: "rgba(255,255,255,0.06)",
+                border: "1px solid rgba(255,255,255,0.10)",
+                fontSize: "0.7rem",
+              }}
+            />
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/widgets/ProblemFilterMenu.js
+++ b/components/widgets/ProblemFilterMenu.js
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import {
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  FormControlLabel,
+  FormGroup,
+  IconButton,
+  Popover,
+  Typography,
+} from "@mui/material";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import { buildFacetOptions } from "../hooks/ProblemFilters/facetOptions";
+
+function toggle(set, key) {
+  const next = new Set(set);
+  if (next.has(key)) {
+    next.delete(key);
+  } else {
+    next.add(key);
+  }
+  return next;
+}
+
+function FacetGroup({ title, options, selected, onChange }) {
+  return (
+    <Box sx={{ mb: 1.5 }}>
+      <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 0.5 }}>
+        {title}
+      </Typography>
+      <FormGroup>
+        {options.length === 0 ? (
+          <Typography variant="body2" sx={{ fontStyle: "italic", color: "text.secondary" }}>
+            No values available
+          </Typography>
+        ) : (
+          options.map(({ key, label, count }) => (
+            <FormControlLabel
+              key={key}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={selected.has(key)}
+                  onChange={() => onChange(toggle(selected, key))}
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  {label} <Box component="span" sx={{ color: "text.secondary" }}>({count})</Box>
+                </Typography>
+              }
+            />
+          ))
+        )}
+      </FormGroup>
+    </Box>
+  );
+}
+
+/**
+ * Filter button + popover for the problem dropdown -- lets the user restrict
+ * which problems appear by complexity class and/or solver Big-O bucket
+ * (worst-case complexity of any solver the problem has). Facet option lists
+ * are derived from `problemIndex` (see `useProblemIndex`), so only values
+ * actually present show up.
+ */
+export default function ProblemFilterMenu({
+  problemIndex,
+  selectedComplexityClasses,
+  setSelectedComplexityClasses,
+  selectedSolverComplexityBuckets,
+  setSelectedSolverComplexityBuckets,
+  clearFilters,
+}) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const complexityClassOptions = buildFacetOptions(problemIndex, (tags) => [tags.complexityClass]);
+  const solverComplexityBucketOptions = buildFacetOptions(
+    problemIndex,
+    (tags) => tags.solverComplexityBuckets,
+  );
+
+  const activeCount = selectedComplexityClasses.size + selectedSolverComplexityBuckets.size;
+
+  return (
+    <>
+      <IconButton onClick={(e) => setAnchorEl(e.currentTarget)}>
+        <Badge badgeContent={activeCount} color="secondary">
+          <FilterListIcon fontSize="medium" />
+        </Badge>
+      </IconButton>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        disableRestoreFocus
+      >
+        <Box sx={{ p: 2, minWidth: 240, maxWidth: 320 }}>
+          <FacetGroup
+            title="Complexity class"
+            options={complexityClassOptions}
+            selected={selectedComplexityClasses}
+            onChange={setSelectedComplexityClasses}
+          />
+
+          <Divider sx={{ my: 1.5 }} />
+
+          <FacetGroup
+            title="Solver Big-O (worst case)"
+            options={solverComplexityBucketOptions}
+            selected={selectedSolverComplexityBuckets}
+            onChange={setSelectedSolverComplexityBuckets}
+          />
+
+          <Button size="small" onClick={clearFilters} disabled={activeCount === 0}>
+            Clear filters
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/components/widgets/ResponsiveAppBar.js
+++ b/components/widgets/ResponsiveAppBar.js
@@ -19,7 +19,7 @@ import {
 import { Adb as AdbIcon } from '@mui/icons-material'; // Grouped icons safely
 
 //const pages = ['Home', 'Tutorials', 'About Us', 'Navigation Graph'];
-const pages = ['Home', 'About Us']
+const pages = ['Home', 'About Us', 'Browse']
 
 const ResponsiveAppBar = () => {
     return (

--- a/components/widgets/SearchBarExtensible.js
+++ b/components/widgets/SearchBarExtensible.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Autocomplete, TextField, Paper, Divider, Button } from "@mui/material";
+import { Autocomplete, TextField, Paper, Divider, Button, ListSubheader } from "@mui/material";
 
 export default function SearchBarExtensible({
   selected,
@@ -8,9 +8,18 @@ export default function SearchBarExtensible({
   options,
   optionsMap,
   optionsHighlight = null,
+  optionsDisabled = null,
+  disabledOptionHint = "",
   disabled = false,
   disabledMessage = "",
   extenderButtons = [],
+  // Optional sectioning: (key) => group label, e.g. a problem's complexity
+  // class. Options are sorted by group first (falling back to optionsHighlight/
+  // alphabetical within a group) so MUI Autocomplete can render section headers.
+  groupBy = null,
+  // Optional explicit ordering for group labels (e.g. ["P", "NPComplete", ...]).
+  // Falls back to alphabetical when omitted.
+  groupOrder = null,
   ...props
 }) {
   const [input, setInput] = useState("");
@@ -36,10 +45,27 @@ export default function SearchBarExtensible({
         }
       }}
       options={Array.isArray(options)
-        ? options
-          .sort(optionsHighlight ? (a, b) => sortHighlights(a, b, optionsHighlight) : undefined)
+        ? [...options]
+          .sort((a, b) => sortOptions(a, b, { groupBy, groupOrder, optionsHighlight }))
           .map((x) => optionsMap.get(x) ?? x)
         : []}
+      groupBy={groupBy ? (option) => groupBy(getKeyByValue(optionsMap, option)) ?? "Unclassified" : undefined}
+      // Bolds the group header so it reads as a section divider, not a selectable option.
+      renderGroup={
+        groupBy
+          ? (params) => (
+            <li key={params.key}>
+              <ListSubheader sx={{ fontWeight: 700 }}>{params.group}</ListSubheader>
+              {params.children}
+            </li>
+          )
+          : undefined
+      }
+      getOptionDisabled={
+        optionsDisabled
+          ? (option) => optionsDisabled.includes(getKeyByValue(optionsMap, option))
+          : undefined
+      }
       disabled={disabled}
       selectOnFocus
       clearOnBlur
@@ -61,17 +87,22 @@ export default function SearchBarExtensible({
           }}
         />
       )}
-      // For rendering highlighted options with greater opacity
+      // Renders de-emphasized (optionsHighlight, still clickable -- ReduceToRowReact's
+      // rank-and-de-emphasize usage) and/or disabled (optionsDisabled, not clickable, e.g.
+      // "no renderer available") options.
       renderOption={
-        optionsHighlight
-          ? (props, option) => (
-            <li
-              {...props}
-              style={optionsHighlight.includes(getKeyByValue(optionsMap, option)) ? null : { opacity: 0.5 }}
-            >
-              {option}
-            </li>
-          )
+        optionsHighlight || optionsDisabled
+          ? (props, option) => {
+            const key = getKeyByValue(optionsMap, option);
+            const isDeemphasized = optionsHighlight ? !optionsHighlight.includes(key) : false;
+            const isDisabledOption = optionsDisabled ? optionsDisabled.includes(key) : false;
+            return (
+              <li {...props} style={isDeemphasized ? { opacity: 0.5 } : null}>
+                {option}
+                {isDisabledOption && disabledOptionHint ? ` (${disabledOptionHint})` : ""}
+              </li>
+            );
+          }
           : null
       }
     />
@@ -81,6 +112,25 @@ export default function SearchBarExtensible({
 /// Gives greater precedence to options contained in the `highlights` arrays.
 function sortHighlights(a, b, highlights) {
   return -(highlights.indexOf(a) - highlights.indexOf(b));
+}
+
+/// Primary sort by group label (if `groupBy` is given -- required by MUI Autocomplete
+/// so same-group options end up contiguous), then falls back to the existing
+/// highlight-based sort, then alphabetical on the raw key.
+function sortOptions(a, b, { groupBy, groupOrder, optionsHighlight }) {
+  if (groupBy) {
+    const groupA = groupBy(a) ?? "Unclassified";
+    const groupB = groupBy(b) ?? "Unclassified";
+    if (groupA !== groupB) {
+      return groupOrder
+        ? groupOrder.indexOf(groupA) - groupOrder.indexOf(groupB)
+        : groupA.localeCompare(groupB);
+    }
+  }
+  if (optionsHighlight) {
+    return sortHighlights(a, b, optionsHighlight);
+  }
+  return String(a).localeCompare(String(b));
 }
 
 function SearchBarPaper({ children, input, optionsMap, extenderButtons }) {

--- a/components/widgets/VisualizationLogic.js
+++ b/components/widgets/VisualizationLogic.js
@@ -4,8 +4,9 @@
 import Split from 'react-split'
 import { useEffect, useState } from 'react';
 import { Container } from '@mui/material';
-import { No_Viz_Svg, No_Reduction_Viz_Svg } from '../Visualization/svgs/No_Viz_SVG';
+import { No_Renderable_Viz_Svg, Viz_Render_Error_Svg } from '../Visualization/svgs/No_Viz_SVG';
 import Visualizations from '../Visualization/svgs/Visualizations.js'
+import { isRenderable } from '../Visualization/svgs/renderability';
 import { remapIdsDeep, makeIdsUnique, processReductions } from '../redux';
 
 export default function VisualizationLogic({
@@ -65,25 +66,54 @@ useEffect(() => {
 
 
 if (url && problemInstance && mappedProblemData && Object.keys(mappedProblemData).length > 0) {
-  try {
-      console.log(mappedProblemData)
-    visualization = Visualizations.get(visualizationType)(solve, url, mappedProblemData, gadgetMap, visualizationState.gadgetsOn)
-  } catch {
-    visualization = <No_Viz_Svg niceProblemName={problemNameMap.get(problemName)} />
+  if (!isRenderable(visualizationType)) {
+    visualization = (
+      <No_Renderable_Viz_Svg
+        niceProblemName={problemNameMap.get(problemName)}
+        visualizationType={visualizationType}
+      />
+    )
+  } else {
+    try {
+      visualization = Visualizations.get(visualizationType)(solve, url, mappedProblemData, gadgetMap, visualizationState.gadgetsOn)
+    } catch (err) {
+      console.error("visualization renderer threw", visualizationType, err)
+      visualization = (
+        <Viz_Render_Error_Svg
+          niceProblemName={problemNameMap.get(problemName)}
+          visualizationType={visualizationType}
+        />
+      )
+    }
   }
 
   if (visualizationState.reductionOn) {
-    try {
-      reducedVisualization = Visualizations.get(reductionVisualization)(solve, url, mappedReductionData, gadgetMap, visualizationState.gadgetsOn)
+    if (!isRenderable(reductionVisualization)) {
+      reducedVisualization = (
+        <No_Renderable_Viz_Svg
+          niceReductionName={reductionNameMap.get(chosenReductionType)}
+          visualizationType={reductionVisualization}
+        />
+      )
+    } else {
+      try {
+        reducedVisualization = Visualizations.get(reductionVisualization)(solve, url, mappedReductionData, gadgetMap, visualizationState.gadgetsOn)
 
-      //NOTE - Caleb, The following is a temporary fix until CLIQUE_SVG_REACT.js is fixed, currently it takes the 3sat instance, 
-      // but should take the clique instance, once that is fixed the following code block should be able to be removed without issue
-      if (reductionName == "CLIQUE") {
-        //reducedVisualization = ReducedVisualizations.get(chosenReductionType)(solve, url, problemInstance, mappedSolution)
+        //NOTE - Caleb, The following is a temporary fix until CLIQUE_SVG_REACT.js is fixed, currently it takes the 3sat instance,
+        // but should take the clique instance, once that is fixed the following code block should be able to be removed without issue
+        if (reductionName == "CLIQUE") {
+          //reducedVisualization = ReducedVisualizations.get(chosenReductionType)(solve, url, problemInstance, mappedSolution)
+        }
+
+      } catch (err) {
+        console.error("reduction visualization renderer threw", reductionVisualization, err)
+        reducedVisualization = (
+          <Viz_Render_Error_Svg
+            niceReductionName={reductionNameMap.get(chosenReductionType)}
+            visualizationType={reductionVisualization}
+          />
+        )
       }
-
-    } catch {
-      reducedVisualization = <No_Reduction_Viz_Svg reducedVisualization={reductionNameMap.get(chosenReductionType)} />
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix",
     "format": "biome check --write .",
     "format:check": "biome check .",
+    "check:visualizations": "node Tools/check-visualization-coverage.mjs",
     "postinstall": "next telemetry disable"
   },
   "dependencies": {

--- a/pages/browse/index.js
+++ b/pages/browse/index.js
@@ -1,0 +1,241 @@
+import React, { useMemo } from "react";
+import ResponsiveAppBar from "../../components/widgets/ResponsiveAppBar";
+import FacetFilterGroup from "../../components/widgets/FacetFilterGroup";
+import ProblemCard from "../../components/widgets/ProblemCard";
+import SearchBarExtensible from "../../components/widgets/SearchBarExtensible";
+import { useProblemIndex } from "../../components/hooks/ProblemFilters/useProblemIndex";
+import { useProblemFilters } from "../../components/hooks/ProblemFilters/useProblemFilters";
+import { buildFacetOptions } from "../../components/hooks/ProblemFilters/facetOptions";
+import {
+  createTheme,
+  ThemeProvider,
+  CssBaseline,
+  Container,
+  Box,
+  Typography,
+  Grid,
+  Button,
+  Chip,
+  CircularProgress,
+} from "@mui/material";
+
+// Same dark palette as pages/aboutus/index.js, for visual consistency across
+// the app's newer MUI-Grid-card pages.
+const theme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: { main: "#8b5cf6" },
+    secondary: { main: "#a855f7" },
+    background: {
+      default: "#07070b",
+      paper: "rgba(255,255,255,0.04)",
+    },
+    text: {
+      primary: "#ffffff",
+      secondary: "#b4b4c7",
+    },
+  },
+  typography: {
+    fontFamily:
+      'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  },
+});
+
+const theSectionCard = {
+  background: "rgba(255,255,255,0.05)",
+  backdropFilter: "blur(10px)",
+  borderRadius: "16px",
+  border: "1px solid rgba(255,255,255,0.10)",
+  padding: { xs: 2, md: 2.5 },
+};
+
+const reduxBaseUrl = "/api/redux/";
+
+export default function BrowsePage() {
+  const { problemIndex, reductionGraph, loading } = useProblemIndex(reduxBaseUrl);
+  const {
+    selectedComplexityClasses,
+    setSelectedComplexityClasses,
+    selectedSolverTypes,
+    setSelectedSolverTypes,
+    selectedVisualizationTypes,
+    setSelectedVisualizationTypes,
+    reachabilitySource,
+    setReachabilitySource,
+    reachabilityMode,
+    setReachabilityMode,
+    filteredProblems,
+    clearFilters,
+  } = useProblemFilters(problemIndex, reductionGraph);
+
+  const complexityClassOptions = useMemo(
+    () => buildFacetOptions(problemIndex, (tags) => [tags.complexityClass]),
+    [problemIndex],
+  );
+  const solverTypeOptions = useMemo(
+    () => buildFacetOptions(problemIndex, (tags) => tags.solverTypes),
+    [problemIndex],
+  );
+  const visualizationTypeOptions = useMemo(
+    () => buildFacetOptions(problemIndex, (tags) => tags.visualizationTypes),
+    [problemIndex],
+  );
+
+  const problemNames = useMemo(() => [...problemIndex.keys()].sort(), [problemIndex]);
+  const problemNameMap = useMemo(
+    () => new Map(problemNames.map((name) => [name, name])),
+    [problemNames],
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box
+        sx={{
+          minHeight: "100vh",
+          background:
+            "radial-gradient(circle at top, rgba(139,92,246,0.16), transparent 32%), linear-gradient(180deg, #09090f 0%, #07070b 100%)",
+        }}
+      >
+        <ResponsiveAppBar />
+
+        <Container maxWidth="lg" sx={{ pt: 3, pb: 6 }}>
+          <Typography sx={{ color: "#ffffff", fontSize: "1.4rem", fontWeight: 600, mb: 0.5 }}>
+            Browse Problems
+          </Typography>
+          <Typography sx={{ color: "#9ca3af", fontSize: "0.87rem", mb: 3 }}>
+            Filter the full problem list by complexity class, solver type, visualization type,
+            or reduction reachability.
+          </Typography>
+
+          {loading ? (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, py: 6 }}>
+              <CircularProgress size={22} sx={{ color: "#a855f7" }} />
+              <Typography sx={{ color: "#d1d5db" }}>Loading problem data…</Typography>
+            </Box>
+          ) : (
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12, md: 3 }}>
+                <Box sx={{ ...theSectionCard, display: "grid", gap: 2.5, position: { md: "sticky" }, top: { md: 16 } }}>
+                  <FacetFilterGroup
+                    label="Complexity Class"
+                    options={complexityClassOptions}
+                    selected={selectedComplexityClasses}
+                    onChange={setSelectedComplexityClasses}
+                  />
+                  <FacetFilterGroup
+                    label="Solver Type"
+                    options={solverTypeOptions}
+                    selected={selectedSolverTypes}
+                    onChange={setSelectedSolverTypes}
+                  />
+                  <FacetFilterGroup
+                    label="Visualization Type"
+                    options={visualizationTypeOptions}
+                    selected={selectedVisualizationTypes}
+                    onChange={setSelectedVisualizationTypes}
+                  />
+
+                  <Box>
+                    <Typography
+                      sx={{
+                        color: "#ffffff",
+                        fontSize: "0.78rem",
+                        fontWeight: 600,
+                        letterSpacing: "0.14em",
+                        mb: 0.5,
+                      }}
+                    >
+                      REACHABLE FROM
+                    </Typography>
+                    <SearchBarExtensible
+                      selected={reachabilitySource ?? ""}
+                      onSelect={(value) => setReachabilitySource(value || null)}
+                      placeholder="Source problem"
+                      options={problemNames}
+                      optionsMap={problemNameMap}
+                      extenderButtons={() => []}
+                    />
+                    <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
+                      <Chip
+                        label="One reduction"
+                        clickable
+                        onClick={() => setReachabilityMode("oneHop")}
+                        sx={{
+                          fontSize: "0.72rem",
+                          color: reachabilityMode === "oneHop" ? "#fff" : "#9ca3af",
+                          background:
+                            reachabilityMode === "oneHop"
+                              ? "rgba(168,85,247,0.45)"
+                              : "rgba(255,255,255,0.06)",
+                          border: "1px solid rgba(255,255,255,0.10)",
+                        }}
+                      />
+                      <Chip
+                        label="Any reductions"
+                        clickable
+                        onClick={() => setReachabilityMode("anyHops")}
+                        sx={{
+                          fontSize: "0.72rem",
+                          color: reachabilityMode === "anyHops" ? "#fff" : "#9ca3af",
+                          background:
+                            reachabilityMode === "anyHops"
+                              ? "rgba(168,85,247,0.45)"
+                              : "rgba(255,255,255,0.06)",
+                          border: "1px solid rgba(255,255,255,0.10)",
+                        }}
+                      />
+                    </Box>
+                  </Box>
+
+                  <Button
+                    onClick={clearFilters}
+                    variant="outlined"
+                    size="small"
+                    sx={{
+                      color: "#e9d5ff",
+                      borderColor: "rgba(168,85,247,0.4)",
+                      "&:hover": { borderColor: "#a855f7", background: "rgba(168,85,247,0.08)" },
+                    }}
+                  >
+                    Clear filters
+                  </Button>
+                </Box>
+              </Grid>
+
+              <Grid size={{ xs: 12, md: 9 }}>
+                <Typography sx={{ color: "#9ca3af", fontSize: "0.82rem", mb: 1.5 }}>
+                  {filteredProblems.length} problem{filteredProblems.length === 1 ? "" : "s"}
+                </Typography>
+
+                {filteredProblems.length === 0 ? (
+                  <Box sx={{ ...theSectionCard, textAlign: "center", py: 5 }}>
+                    <Typography sx={{ color: "#9ca3af" }}>
+                      No problems match the current filters.
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Grid container spacing={1.5}>
+                    {filteredProblems.map((name) => {
+                      const tags = problemIndex.get(name);
+                      return (
+                        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={name}>
+                          <ProblemCard
+                            name={name}
+                            complexityClass={tags.complexityClass}
+                            solverTypes={[...tags.solverTypes].sort()}
+                            hasRenderableVisualization={tags.hasRenderableVisualization}
+                          />
+                        </Grid>
+                      );
+                    })}
+                  </Grid>
+                )}
+              </Grid>
+            </Grid>
+          )}
+        </Container>
+      </Box>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
Frontend (Redux_GUI)

1. Visualization renderability: renderability.js, visualizationTypes.json, auto-select prefers a renderable option, picker greys out non-renderable choices.

2. Info-button tooltips (this session): every info popover (Problem/Solver/Reduction/Visualization) now shows a Classification section (complexity class, solver type + Big-O + complexity bucket, reduction cost, visualization type), plus bigger, more visible icons.

3. Problem filtering & sectioning (this session) — a filter button next to the problem dropdown with facets for complexity class and solver Big-O bucket, and the dropdown itself is now grouped into bold-headed sections by complexity class.

4. Browse page: dedicated /browse page with facet filters (complexity class, solver type, visualization type) plus a reduction-reachability filter.

5. SSSP table visualization: a separate, already-merged-in feature branch's work (table-based SSSP viz + column formatting).

6. CI: new manifest-drift.yml workflow enforcing the backend/frontend visualization-type registries never drift apart.