### PR TITLE
ci: add devcontainer, mise tasks, and rbs pipeline

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/reduxisu/features/rbs:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/reduxisu/features/rbs@sha256:65cfaf2554fb1707ea84cf34f3defbd1f34ba528b359627e70e423f7ac7da3e6",
+      "integrity": "sha256:65cfaf2554fb1707ea84cf34f3defbd1f34ba528b359627e70e423f7ac7da3e6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Redux GUI Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "26" },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": { "moby": false },
+    "ghcr.io/reduxisu/features/rbs:1": {}
+  },
+  "appPort": [3000],
+  "portsAttributes": {
+    "3000": { "label": "Redux GUI (Next.js)", "onAutoForward": "notify" }
+  },
+  "mounts": [
+    "source=redux_gui-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+    "source=redux_gui-next,target=${containerWorkspaceFolder}/.next,type=volume"
+  ],
+  "containerEnv": { "DEV_HOST": "0.0.0.0" },
+  "containerUser": "vscode",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "postStartCommand": "if [ \"$(stat -c %U /workspaces/Redux_GUI)\" != \"vscode\" ]; then sudo chown -R vscode:vscode /workspaces/Redux_GUI; fi",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "biomejs.biome"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mise supplies dev-loop aliases only (rbs owns the gates), and this script also runs in CI via
+# devcontainers/ci — so a mise.run outage must not fail container creation or redden a PR.
+if ! command -v mise >/dev/null 2>&1; then
+  curl -fsSL https://mise.run | sh || echo "warn: mise install failed; 'mise run ...' unavailable"
+fi
+MISE="$(command -v mise || true)"
+[ -n "${MISE}" ] || MISE="${HOME}/.local/bin/mise"
+if [ -x "${MISE}" ]; then
+  grep -qF 'mise activate bash' "${HOME}/.bashrc" 2>/dev/null || echo "eval \"\$(${MISE} activate bash)\"" >> "${HOME}/.bashrc"
+  "${MISE}" trust
+fi
+
+# node_modules and .next are container-local volumes; make them writable by this user.
+sudo chown "$(id -u):$(id -g)" node_modules .next
+
+# Seed local env from template, then install deps.
+[ -f .env.local ] || cp .env.example .env.local
+npm ci

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Backend the GUI proxies to (server-side). Copy to .env.local to change.
+# Default: live production API — real data, no local backend.
+REDUX_BASE_URL=https://redux.isu.edu/api/redux/
+
+# Local backend instead (Redux devcontainer, :27000):
+# REDUX_BASE_URL=http://host.docker.internal:27000/
+
+NEXT_TELEMETRY_DISABLED=1

--- a/.github/workflows/rbs.yml
+++ b/.github/workflows/rbs.yml
@@ -1,0 +1,22 @@
+name: rbs
+
+on:
+  pull_request:
+  push:
+    branches: [ReduxAPI_GUI]
+
+permissions:
+  contents: read
+  pull-requests: write
+  packages: write
+
+concurrency:
+  group: rbs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    uses: ReduxISU/Redux_Build_System/.github/workflows/ci.yml@main
+    secrets: inherit
+    with:
+      soft: true

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ pids
 .cache/
 .next/cache/
 .eslintcache
+cache/
+
+# Redux Build System output
+.rbs/
+report.md
 
 # ESLint SARIF output
 eslint-results.sarif

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,7 @@
   "linter": {
     "enabled": false,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "javascript": {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,21 @@
+# Shared tasks. Node from the devcontainer feature (no [tools]); bind defaults to loopback, devcontainer sets 0.0.0.0.
+
+[tasks.dev]
+description = "Run the dev server on http://localhost:3000"
+run = "npm run dev -- -H ${DEV_HOST:-127.0.0.1} -p 3000"
+
+[tasks.build]
+description = "Production build"
+run = "npm run build"
+
+[tasks.lint]
+description = "Lint with ESLint"
+run = "npm run lint"
+
+[tasks.format]
+description = "Format with Biome"
+run = "npm run format"
+
+[tasks."format:check"]
+description = "Check formatting (no writes)"
+run = "npm run format:check"

--- a/rbs.toml
+++ b/rbs.toml
@@ -1,0 +1,17 @@
+# Redux Build System pipeline config. See github.com/ReduxISU/Redux_Build_System.
+engine = "npm"
+
+[artifact]
+image = "ghcr.io/reduxisu/redux_gui"
+port = 3000
+health-path = "/"
+
+# `unit-test` reports `skipped` until package.json gains a `test` script — it never passes
+# vacuously. `integration-test` and `push` are not implemented in rbs yet and report `skipped`.
+#
+# When integration-test lands it needs a backend container alongside the GUI image (the proxy is
+# useless without one) wired via REDUX_BASE_URL. Those keys are added with that implementation
+# rather than guessed at here.
+
+[push]
+on-branch = "ReduxAPI_GUI"


### PR DESCRIPTION
Set up a reproducible dev environment and build pipeline:

- Add devcontainer with Node, docker-outside-of-docker, and rbs features so contributors get a consistent local setup
- Add post-create script to install mise, fix volume permissions, seed .env.local, and install dependencies
- Add mise.toml with shared dev/build/lint/format tasks
- Add rbs.toml to configure the Redux Build System pipeline, targeting ghcr.io/reduxisu/redux_gui on port 3000
- Add .env.example documenting REDUX_BASE_URL for switching between production and local backends
- Ignore rbs and generic cache output in .gitignore