### PR TITLE
Fix TypeError crash in GraphLaTeX renderer when nodes/links are missing

### DIFF
--- a/components/Visualization/svgs/LaTeXGraphSvgReact.js
+++ b/components/Visualization/svgs/LaTeXGraphSvgReact.js
@@ -51,7 +51,7 @@ function LaTeXGraphSvgReact({ problemData }) {
 
       const rand = seededRandom(12345);
 
-      const nodes = problemData.nodes.map((n) => ({
+      const nodes = (problemData.nodes || []).map((n) => ({
         ...n,
         x: rand() * 10,
         y: rand() * 10,
@@ -59,7 +59,7 @@ function LaTeXGraphSvgReact({ problemData }) {
         vy: 0,
       }));
 
-      const links = problemData.links;
+      const links = problemData.links || [];
 
       const iterations = 200;
       const repulsion = 0.4;


### PR DESCRIPTION
problemData.nodes.map() threw "Cannot read properties of undefined (reading 'map')" whenever a frame arrived without a nodes or links array, crashing DFA/NFA Acceptance visualizations. Normalize both to [] before use, matching the same guard already in
StandardGraphSvgReact.js (the D3 graph renderer).

Fixes #168